### PR TITLE
Add pictos count near title

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Clair Obscur - Picto Inventory</title>
+  <title>Clair Obscur - Pictos</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/js/script.js
+++ b/js/script.js
@@ -5,6 +5,15 @@
     let myPictosSet = new Set();
     let currentView = "cards";
     let sortCol = null, sortDir = 1; // 1 asc, -1 desc
+    let ownedCount = 0;
+    let totalCount = 0;
+
+    function updateTitle() {
+      const suffix = ` - ${ownedCount}/${totalCount}`;
+      const h1 = document.querySelector("h1");
+      if (h1) h1.textContent = `Clair Obscur - Pictos${suffix}`;
+      document.title = `Clair Obscur - Pictos${suffix}`;
+    }
 
     // Traduction pour badges
     const pictoLabels = {
@@ -35,6 +44,9 @@
       pictos = data;
       pictosFiltered = pictos.slice();
       myPictosSet = new Set((myData || []).filter(x => x.ref).map(x => x.ref));
+      ownedCount = myPictosSet.size;
+      totalCount = pictos.length;
+      updateTitle();
       render();
     });
 


### PR DESCRIPTION
## Summary
- update page title text
- show owned/total pictos count next to header and document title

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6877e1f7848c832c8c6b7a4ee3948b9b