### PR TITLE
Màj de la responsivité et du visuel de sélection

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -72,9 +72,9 @@
       border: 1px solid #2c3142;
     }
     .card.owned {
-      background: linear-gradient(120deg, #254B2F 60%, #23263a 100%);
-      border-color: #2c6b48;
-      box-shadow: 0 4px 20px #214b2f88;
+      background: linear-gradient(120deg, #1b3d24 60%, #23263a 100%);
+      border-color: #1f5034;
+      box-shadow: 0 4px 20px #1a382088;
     }
     .card:hover {
       box-shadow: 0 6px 16px #000a;
@@ -193,7 +193,7 @@
     th.sorted-asc:after { content: " ⬆️"; font-size: 0.85em; }
     th.sorted-desc:after { content: " ⬇️"; font-size: 0.85em; }
     tr.owned td, tr.owned th {
-      background: #214b2f !important;
+      background: #1a3820 !important;
     }
     .checkbox-cell {
       text-align: center;

--- a/js/script.js
+++ b/js/script.js
@@ -22,9 +22,9 @@
       modal.style.display = 'flex';
     }
 
-    document.addEventListener('click', e => {
+    document.addEventListener('click', () => {
       const modal = document.getElementById('modal');
-      if(modal && e.target === modal) modal.style.display = 'none';
+      if(modal && modal.style.display !== 'none') modal.style.display = 'none';
     });
 
     function updateTitle() {
@@ -259,7 +259,10 @@
         cb.addEventListener('change', e => togglePicto(e.target.dataset.id));
       });
       div.querySelectorAll('.info-icon').forEach(ic => {
-        ic.addEventListener('click', e => showModal(e.currentTarget.dataset.info));
+        ic.addEventListener('click', e => {
+          e.stopPropagation();
+          showModal(e.currentTarget.dataset.info);
+        });
       });
     }
 


### PR DESCRIPTION
## Summary
- diminue la couleur verte pour la sélection des cartes et lignes
- ferme la modale info sur n'importe quel clic
- stoppe la propagation lors du clic sur l'icône info

## Testing
- `npm test` *(échoue : package.json manquant)*

------
https://chatgpt.com/codex/tasks/task_e_6877ee2e12a0832cbaa16442259e7e3b