### PR TITLE
Fix counter logic for selected pictos

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -46,11 +46,11 @@ function notify(msg, delay = 3000) {
     });
 
     function updateTitle() {
-      const visible = pictosFiltered.length;
-      const hidden = hiddenCount;
-      const suffix = hidden > 0
-        ? ` - ${visible} (+${hidden} masqués) / ${totalCount}`
-        : ` - ${visible} / ${totalCount}`;
+      const visibleOwned = pictosFiltered.filter(p => myPictosSet.has(p.id)).length;
+      const hiddenOwned = ownedCount - visibleOwned;
+      const suffix = hiddenOwned > 0
+        ? ` - ${visibleOwned} (+${hiddenOwned} masqués) / ${totalCount}`
+        : ` - ${visibleOwned} / ${totalCount}`;
       const h1 = document.querySelector("h1");
       if (h1) h1.textContent = `Clair Obscur - Pictos${suffix}`;
       document.title = `Clair Obscur - Pictos${suffix}`;


### PR DESCRIPTION
## Summary
- correct counter to display selected pictos rather than visible total

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68780651ff68832caaab6fadab8d96c9