### PR TITLE
Add Cinzel font and local save button

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "bootstrap": "^5.3.3"
+    ,"@fontsource/cinzel": "^5.0.5"
   },
   "devDependencies": {
     "lite-server": "^2.6.1"

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,7 +1,7 @@
     body {
       background: #191c23;
       color: #ffffff;
-      font-family: serif;
+      font-family: 'Cinzel', serif;
       margin: 0;
       padding: 0;
     }
@@ -13,6 +13,7 @@
       color: #e0e0ff;
       font-weight: 700;
       margin-bottom: 10px;
+      font-family: 'Cinzel', serif;
     }
     .actions {
       display: flex;
@@ -126,6 +127,11 @@
     }
     .pin-btn {
       cursor: pointer;
+      display: inline-block;
+      transition: transform 0.2s;
+    }
+    .card.owned .pin-btn {
+      transform: rotate(-35deg);
     }
     .name {
       font-size: 1.4em;

--- a/src/index.html
+++ b/src/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Clair Obscur Helper - Pictos inventory</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/bootstrap-lite.css">
   <link rel="stylesheet" href="css/style.css">
 </head>
@@ -22,11 +23,12 @@
       <h1>Pictos inventory</h1>
       <div class="actions">
         <div class="icon-bar">
-          <button class="icon-btn" id="downloadBtn" title="Download">💾</button>
-          <button class="icon-btn" id="uploadBtn" title="Upload">📂</button>
+          <button class="icon-btn" id="downloadBtn" title="Download">⬇️</button>
+          <button class="icon-btn" id="uploadBtn" title="Upload">⬆️</button>
+          <button class="icon-btn" id="saveBtn" title="Sauvegarder">💾</button>
           <div class="icon-sep"></div>
-          <button class="icon-btn toggle" id="hideOwnedBtn" title="Hide owned">🙈</button>
-          <button class="icon-btn toggle" id="hideMissingBtn" title="Hide missing">❓</button>
+          <button class="icon-btn toggle" id="hideOwnedBtn" title="Hide owned">🔒</button>
+          <button class="icon-btn toggle" id="hideMissingBtn" title="Hide missing">👻</button>
           <div class="icon-sep"></div>
           <button class="icon-btn" id="selectAllBtn" title="Select all">✔️</button>
           <button class="icon-btn" id="clearAllBtn" title="Clear all">🗑️</button>

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -182,6 +182,14 @@ function notify(msg, delay = 3000) {
       updateIconStates();
     }
 
+    function saveToLocal() {
+      if(!confirm('Save selection to this browser?')) return;
+      localStorage.setItem('myPictos', JSON.stringify(Array.from(myPictosSet)));
+      modified = false;
+      notify('Selection saved');
+      updateIconStates();
+    }
+
     function selectAll() {
       const total = pictosFiltered.length;
       const selected = pictosFiltered.filter(p => myPictosSet.has(p.id)).length;
@@ -211,6 +219,8 @@ function notify(msg, delay = 3000) {
     function updateIconStates() {
       const downloadBtn = document.getElementById('downloadBtn');
       if(downloadBtn) downloadBtn.classList.toggle('disabled', !modified);
+      const saveBtn = document.getElementById('saveBtn');
+      if(saveBtn) saveBtn.classList.toggle('disabled', !modified);
       const baseFiltered = pictos.filter(p => {
         const term = document.getElementById('search').value.trim().toLowerCase();
         return Object.values(p).some(v => (v && typeof v === 'string' && v.toLowerCase().includes(term)))
@@ -246,7 +256,13 @@ function notify(msg, delay = 3000) {
       pictos = data;
       pictosFiltered = pictos.slice();
       myPictosSet = new Set();
-      ownedCount = 0;
+      const saved = localStorage.getItem('myPictos');
+      if(saved) {
+        try {
+          JSON.parse(saved).forEach(id => myPictosSet.add(id));
+        } catch(e) { /* ignore */ }
+      }
+      ownedCount = myPictosSet.size;
       totalCount = pictos.length;
       dataLoaded = true;
       updateIconStates();
@@ -255,6 +271,7 @@ function notify(msg, delay = 3000) {
 
     document.getElementById('downloadBtn').addEventListener('click', downloadJson);
     document.getElementById('uploadBtn').addEventListener('click', () => document.getElementById('fileInput').click());
+    document.getElementById('saveBtn').addEventListener('click', saveToLocal);
     document.getElementById('fileInput').addEventListener('change', e => {
       if (e.target.files && e.target.files[0]) {
         handleUpload(e.target.files[0]);


### PR DESCRIPTION
## Summary
- depend on `@fontsource/cinzel`
- include Cinzel font from Google Fonts
- tweak body and header fonts
- replace upload/download icons and add new Save button
- style pin icon rotation on selected cards
- store selected pictos in local storage

## Testing
- `node build.js` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878f2485348832ca26970a275a74bdb