### PR TITLE
Fix textures and improve layout

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,5 +1,6 @@
     body {
-      background: #191c23;
+      background: #191c23 url('../resources/images/background_site_1.png') no-repeat center top;
+      background-size: cover;
       color: #ffffff;
       font-family: 'Cinzel', serif;
       margin: 0;
@@ -90,9 +91,9 @@
     @media (min-width: 1920px) {
       .cards { grid-template-columns: repeat(3, 1fr); }
     }
-.card {
+    .card {
       position: relative;
-      background: #23263a;
+      background: #23263a url('../resources/images/background_tile.png') repeat;
       border-radius: 14px;
       box-shadow: 0 2px 8px #0006;
       padding: 22px 20px 18px 20px;
@@ -104,9 +105,9 @@
       z-index: 0;
     }
     .card.owned {
-      background: linear-gradient(120deg, #254B2F 60%, #23263a 100%);
-      border-color: #2c6b48;
+      background: linear-gradient(120deg, #254B2F 60%, #23263a 100%), url('../resources/images/background_tile.png') repeat;
       box-shadow: 0 4px 20px #214b2f88;
+      border-color: #2c3142;
     }
     .card:hover {
       transform: translateY(-2px);
@@ -137,6 +138,7 @@
       font-size: 1.4em;
       font-weight: 700;
       color: #CDB48E;
+      word-wrap: break-word;
     }
     .bonus-list {
       display: flex;
@@ -231,6 +233,7 @@
       margin: 4px 0 2px 0;
       color: #ffffff;
       white-space: pre-line;
+      word-wrap: break-word;
     }
     .description {
       margin-top: 7px;
@@ -364,6 +367,36 @@ footer {
   bottom: 0;
   left: 0;
   width: 100%;
+  overflow: hidden;
+}
+
+footer::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: url('../resources/images/background_header.png') repeat-x top;
+  transform: scaleY(-1);
+  transform-origin: top;
+  z-index: -1;
+}
+
+.navbar {
+  position: relative;
+  min-height: 120px;
+}
+
+.navbar::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: url('../resources/images/background_header.png') repeat-x bottom;
+  z-index: -1;
 }
 
 body {


### PR DESCRIPTION
## Summary
- make header/footer textures tile cleanly
- tile texture background of cards
- remove green border on owned cards
- avoid text overflow on cards
- adjust gradient overlay order

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68791dd6f828832c80346dcd7687d838