### PR TITLE
Update tile background

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -105,7 +105,7 @@
       z-index: 0;
     }
     .card.owned {
-      background: linear-gradient(120deg, #254B2F 60%, #23263a 100%), url('../resources/images/background_tile.png') repeat;
+      background: #23263a url('../resources/images/background_tile.png') repeat;
       box-shadow: 0 4px 20px #214b2f88;
       border-color: #2c3142;
     }


### PR DESCRIPTION
## Summary
- remove the green overlay from owned tiles
- reuse `background_tile.png` for owned card backgrounds

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68792442d050832cb1d4521dbc95373a