### PR TITLE
Fix duplicate backgrounds

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -97,27 +97,18 @@
       border-left: 20px solid transparent;
       border-right: 20px solid transparent;
       border-image: url('../resources/images/background_tile.png') 0 20 fill stretch;
-      background: url('../resources/images/background_tile.png') no-repeat;
-      background-position: -20px 0;
-      background-size: calc(100% + 40px) 100%;
       border-radius: 14px;
-      box-shadow: 0 2px 8px #0006;
-      padding: 22px 20px 18px 20px;
+      padding: 22px 60px 18px 20px;
       display: flex;
       flex-direction: column;
-      transition: box-shadow .2s, background 0.18s, transform 0.1s;
+      transition: background 0.18s, transform 0.1s;
       z-index: 0;
     }
     .card.owned {
       border-image-source: url('../resources/images/background_tile_selected.png');
-      background: url('../resources/images/background_tile_selected.png') no-repeat;
-      background-position: -20px 0;
-      background-size: calc(100% + 40px) 100%;
-      box-shadow: 0 4px 20px #214b2f88;
     }
     .card:hover {
       transform: translateY(-2px);
-      box-shadow: 0 6px 16px #000a;
     }
     .region {
       color: #7cc9ff;


### PR DESCRIPTION
## Summary
- remove redundant tile backgrounds and box-shadows
- enlarge card right padding for better spacing

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68793e76ddf0832c90f0b775f7b573bd