### PR TITLE
Fix tile back padding

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -177,6 +177,7 @@
     }
     .card-back {
       transform: rotateY(180deg);
+      padding-left: 26px;
     }
     .card.flipped .card-inner,
     .card.pinned .card-inner {


### PR DESCRIPTION
## Summary
- bump up padding-left for `.card-back` so flipped tiles don't overflow

## Testing
- `npm run build --silent`


------
https://chatgpt.com/codex/tasks/task_e_6879636ffd1c832c9428e27af9e2f79e