### PR TITLE
Adjust padding for cards and footer

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -173,11 +173,12 @@
       display: flex;
       flex-direction: column;
       box-sizing: border-box;
-      padding: 22px 20px 18px 20px;
+      padding: 22px 24px 18px 24px;
     }
     .card-back {
       transform: rotateY(180deg);
-      padding-left: 26px;
+      padding-left: 30px;
+      padding-right: 30px;
     }
     .card.flipped .card-inner,
     .card.pinned .card-inner {
@@ -366,7 +367,7 @@
     overflow: hidden;
     background: url('../resources/images/background_site_header_footer.png') repeat;
     z-index: 3000;
-    padding: 18px 0;
+    padding: 28px 0 18px;
   }
 
   footer::before {


### PR DESCRIPTION
## Summary
- expand padding inside card faces
- add symmetric padding on the card back
- increase top padding for footer

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68796ca360b8832c9080cfc8ca20d9f3