### PR TITLE
Add click flip with pressure effect and AOS

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -115,9 +115,6 @@
     .card.owned .card-inner {
       background-image: url('../resources/images/background_tile_selected.png');
     }
-    .card:hover {
-      transform: translateY(-2px);
-    }
     .region {
       color: #7cc9ff;
       font-size: 0.93em;
@@ -410,4 +407,15 @@
 body {
   padding-top: 145px;
   padding-bottom: 80px;
+}
+
+/* AOS custom animation for flip with zoom */
+[data-aos="flip-zoom"] {
+  transform: perspective(1000px) rotateY(90deg) scale(0.5);
+  opacity: 0;
+  transition-property: transform, opacity;
+}
+[data-aos="flip-zoom"].aos-animate {
+  transform: perspective(1000px) rotateY(0) scale(1);
+  opacity: 1;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
   <link rel="stylesheet" href="css/bootstrap-lite.css">
   <link rel="stylesheet" href="css/style.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css">
 </head>
 <body class="d-flex flex-column min-vh-100">
   <nav class="navbar navbar-dark">
@@ -49,7 +50,11 @@
   <footer class="text-center text-white py-3">
     Copyright oPyRuSo 2025-<span id="year"></span>
   </footer>
+  <script src="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.js"></script>
   <script src="js/script.js"></script>
-  <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+  <script>
+    AOS.init();
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
 </body>
 </html>

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -347,6 +347,7 @@ function notify(msg, delay = 3000) {
         const owned = myPictosSet.has(p.id);
         const card = document.createElement("div");
         card.className = "card" + (owned ? " owned" : "");
+        card.setAttribute('data-aos', 'flip-zoom');
 
         let front = `<div class="card-face card-front">`;
         front += `<div class="card-header"><span class="pin-btn" data-id="${p.id}"><i class="fa-solid fa-thumbtack"></i></span><span class="name">${p.name}</span></div>`;
@@ -374,9 +375,17 @@ function notify(msg, delay = 3000) {
 
         card.innerHTML = `<div class="card-inner">${front}${back}</div>`;
 
-        card.addEventListener('mouseenter', () => card.classList.add('flipped'));
+        card.addEventListener('mousemove', e => {
+          const rect = card.getBoundingClientRect();
+          const x = (e.clientX - rect.left) / rect.width - 0.5;
+          const y = (e.clientY - rect.top) / rect.height - 0.5;
+          const maxDeg = 8;
+          const rx = y * maxDeg;
+          const ry = -x * maxDeg;
+          card.style.transform = `rotateX(${rx}deg) rotateY(${ry}deg)`;
+        });
         card.addEventListener('mouseleave', () => {
-          if(!card.classList.contains('pinned')) card.classList.remove('flipped');
+          card.style.transform = '';
         });
         card.addEventListener('click', e => {
           const pin = e.target.closest('.pin-btn');
@@ -384,12 +393,12 @@ function notify(msg, delay = 3000) {
             e.stopPropagation();
             togglePicto(pin.dataset.id);
           } else {
-            card.classList.toggle('pinned');
-            card.classList.toggle('flipped', card.classList.contains('pinned'));
+            card.classList.toggle('flipped');
           }
         });
         container.appendChild(card);
       });
+      if (window.AOS) AOS.refresh();
     }
 
     // Vue Tableau


### PR DESCRIPTION
## Summary
- make cards flip on click instead of hover
- apply a tilt pressure effect that follows mouse position
- integrate AOS and custom `flip-zoom` animation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68796e728430832c95b22c4065c9d241