### PR TITLE
Adjust card tilt balance

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -65,8 +65,9 @@ function handleCardPressMove(e) {
   const rect = card.getBoundingClientRect();
   const x = e.clientX - rect.left;
   const y = e.clientY - rect.top;
-  const rx = -((y - rect.height / 2) / rect.height);
   const ry = ((x - rect.width / 2) / rect.width);
+  const weight = 0.8 + 0.4 * (y / rect.height);
+  const rx = -((y - rect.height / 2) / rect.height) * weight;
   card.style.transform = `rotateX(${rx}deg) rotateY(${ry}deg)`;
 }
 


### PR DESCRIPTION
## Summary
- tweak `handleCardPressMove` so the rotation is less extreme at the top and a bit stronger at the bottom

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879cee43d28832c81dd2129c5e20649