### PR TITLE
Adjust mobile font sizes

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -332,11 +332,14 @@
   .content-wrapper { padding: 5px; }
   .cards { grid-template-columns: 1fr; }
   th, td { font-size: 0.93em; }
-  html { font-size: 14px; }
+  html { font-size: 13px; }
 }
 
 @media (max-width: 480px) {
-  html { font-size: 12px; }
+  html { font-size: 11px; }
+  .name { font-size: 1.2em; }
+  .level { font-size: 1.2em; }
+  .badge { font-size: 0.86em; }
 }
 
 .notification-container {


### PR DESCRIPTION
## Summary
- tune responsive `html` font sizes
- scale down tile text on small screens

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879d36d8a18832c89dded8d21cfe54f