### PR TITLE
Use simple fade animation on card refresh

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -103,6 +103,13 @@
       transition: transform 0.2s;
       z-index: 0;
     }
+    .card.fade {
+      opacity: 0;
+      transition: opacity 0.3s;
+    }
+    .card.fade.show {
+      opacity: 1;
+    }
     .card-inner {
       position: absolute;
       inset: 0;

--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,6 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
   <link rel="stylesheet" href="css/bootstrap-lite.css">
   <link rel="stylesheet" href="css/style.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.css">
 </head>
 <body class="d-flex flex-column min-vh-100">
   <nav class="navbar navbar-dark">
@@ -51,8 +50,6 @@
     Copyright oPyRuSo 2025-<span id="year"></span>
   </footer>
   <script src="js/script.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
-  <script>AOS.init({ once: true, duration: 500, easing: 'ease-out', offset: 50 });</script>
   <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
 </body>
 </html>

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -381,10 +381,7 @@ function handleCardPressLeave(e) {
         const card = document.createElement("div");
         card.className = "card" + (owned ? " owned" : "");
         card.dataset.id = p.id;
-        if(initialRender) {
-          card.setAttribute('data-aos','fade-up');
-          card.setAttribute('data-aos-duration','500');
-        } else {
+        if(!initialRender) {
           card.classList.add('fade');
         }
 
@@ -430,7 +427,6 @@ function handleCardPressLeave(e) {
         container.appendChild(card);
         if(!initialRender) requestAnimationFrame(() => card.classList.add('show'));
       });
-      if(initialRender && window.AOS) AOS.refresh();
       initialRender = false;
     }
 

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -11,6 +11,7 @@ let hideMissing = false;
 let modified = false;
 let hiddenCount = 0;
 let dataLoaded = false;
+let initialRender = true;
 
     function togglePicto(id) {
       const hadId = myPictosSet.has(id);
@@ -380,8 +381,12 @@ function handleCardPressLeave(e) {
         const card = document.createElement("div");
         card.className = "card" + (owned ? " owned" : "");
         card.dataset.id = p.id;
-        card.setAttribute('data-aos','fade-up');
-        card.setAttribute('data-aos-duration','500');
+        if(initialRender) {
+          card.setAttribute('data-aos','fade-up');
+          card.setAttribute('data-aos-duration','500');
+        } else {
+          card.classList.add('fade');
+        }
 
         let front = `<div class="card-face card-front">`;
         front += `<div class="card-header"><span class="pin-btn" data-id="${p.id}"><i class="fa-solid fa-thumbtack"></i></span><span class="name">${p.name}</span></div>`;
@@ -423,8 +428,10 @@ function handleCardPressLeave(e) {
           }
         });
         container.appendChild(card);
+        if(!initialRender) requestAnimationFrame(() => card.classList.add('show'));
       });
-      if(window.AOS) AOS.refresh();
+      if(initialRender && window.AOS) AOS.refresh();
+      initialRender = false;
     }
 
     // Vue Tableau


### PR DESCRIPTION
## Summary
- avoid heavy AOS refresh when cards are filtered
- fade cards in with a CSS class instead

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879e8550714832c88f3b5e747c7f79a