### PR TITLE
Move main action buttons to header and use png icons

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -50,9 +50,20 @@
   padding: 4px;
   transition: color 0.15s, opacity 0.15s;
 }
+.icon-btn img {
+  width: 24px;
+  height: 24px;
+}
 .icon-btn.toggled,
 .icon-btn:not(.disabled):hover {
   color: #fff;
+}
+.icon-btn:not(.disabled):hover img,
+.icon-btn.toggled img {
+  filter: brightness(1.2);
+}
+.icon-btn.disabled img {
+  opacity: 0.4;
 }
 .icon-btn.disabled {
   opacity: 0.4;
@@ -480,7 +491,6 @@ body[data-page="weapons"] .card-back {
   }
 
   .lang-flags {
-    margin-left: auto;
     margin-right: 10px;
     display: flex;
     gap: 8px;

--- a/src/header.html
+++ b/src/header.html
@@ -5,7 +5,13 @@
       <li class="nav-item"><a class="nav-link" href="index.html" data-page="pictos" data-i18n="nav_pictos">Pictos inventory</a></li>
       <li class="nav-item"><a class="nav-link" href="weapons.html" data-page="weapons" data-i18n="nav_weapons">Weapons inventory</a></li>
     </ul>
-    <div class="lang-flags ms-auto">
+    <div class="icon-bar header-actions ms-auto">
+      <button class="icon-btn" id="downloadBtn" data-i18n-title="download" title="Download"><img src="resources/images/icons/buttons/download.png" alt=""></button>
+      <button class="icon-btn" id="uploadBtn" data-i18n-title="upload" title="Upload"><img src="resources/images/icons/buttons/upload.png" alt=""></button>
+      <button class="icon-btn" id="saveBtn" data-i18n-title="save" title="Save"><img src="resources/images/icons/buttons/save.png" alt=""></button>
+    </div>
+    <div class="icon-sep"></div>
+    <div class="lang-flags">
       <span class="lang-flag fi fi-fr" data-lang="fr" id="frFlag"></span>
       <span class="lang-flag fi fi-gb" data-lang="en" id="enFlag"></span>
     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -16,10 +16,6 @@
       <h1 data-i18n="heading_pictos">Pictos inventory</h1>
       <div class="actions">
         <div class="icon-bar">
-          <button class="icon-btn" id="downloadBtn" data-i18n-title="download" title="Download"><i class="fa-solid fa-download"></i></button>
-          <button class="icon-btn" id="uploadBtn" data-i18n-title="upload" title="Upload"><i class="fa-solid fa-upload"></i></button>
-          <button class="icon-btn" id="saveBtn" data-i18n-title="save" title="Sauvegarder"><i class="fa-solid fa-floppy-disk"></i></button>
-          <div class="icon-sep"></div>
           <button class="icon-btn toggle" id="hideOwnedBtn" data-i18n-title="hide_owned" title="Hide owned"><i class="fa-solid fa-lock"></i></button>
           <button class="icon-btn toggle" id="hideMissingBtn" data-i18n-title="hide_missing" title="Hide missing"><i class="fa-solid fa-ghost"></i></button>
           <div class="icon-sep"></div>

--- a/src/js/common.js
+++ b/src/js/common.js
@@ -12,6 +12,7 @@ async function loadCommon() {
   if(active) active.classList.add('active');
   if(typeof applyTranslations==='function') applyTranslations();
   if(typeof updateFlagState==='function') updateFlagState();
+  document.dispatchEvent(new Event('commonLoaded'));
 }
 
 document.addEventListener('DOMContentLoaded', loadCommon);

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -331,48 +331,55 @@ function handleCardPressLeave(e) {
       applyFilters();
     }
 
-    document.getElementById('downloadBtn').addEventListener('click', downloadJson);
-    document.getElementById('uploadBtn').addEventListener('click', () => document.getElementById('fileInput').click());
-    document.getElementById('saveBtn').addEventListener('click', saveToLocal);
-    document.getElementById('fileInput').addEventListener('change', e => {
-      if (e.target.files && e.target.files[0]) {
-        handleUpload(e.target.files[0]);
-        e.target.value = '';
-      }
-    });
-    document.getElementById('hideOwnedBtn').addEventListener('click', () => {
-      hideOwned = !hideOwned;
-      if(hideOwned) hideMissing = false;
-      applyFilters();
-    });
-    document.getElementById('hideMissingBtn').addEventListener('click', () => {
-      hideMissing = !hideMissing;
-      if(hideMissing) hideOwned = false;
-      applyFilters();
-    });
-    document.getElementById('selectAllBtn').addEventListener('click', selectAll);
-    document.getElementById('clearAllBtn').addEventListener('click', clearAll);
-    updateIconStates();
+    function initPage() {
+      document.getElementById('downloadBtn').addEventListener('click', downloadJson);
+      document.getElementById('uploadBtn').addEventListener('click', () => document.getElementById('fileInput').click());
+      document.getElementById('saveBtn').addEventListener('click', saveToLocal);
+      document.getElementById('fileInput').addEventListener('change', e => {
+        if (e.target.files && e.target.files[0]) {
+          handleUpload(e.target.files[0]);
+          e.target.value = '';
+        }
+      });
+      document.getElementById('hideOwnedBtn').addEventListener('click', () => {
+        hideOwned = !hideOwned;
+        if(hideOwned) hideMissing = false;
+        applyFilters();
+      });
+      document.getElementById('hideMissingBtn').addEventListener('click', () => {
+        hideMissing = !hideMissing;
+        if(hideMissing) hideOwned = false;
+        applyFilters();
+      });
+      document.getElementById('selectAllBtn').addEventListener('click', selectAll);
+      document.getElementById('clearAllBtn').addEventListener('click', clearAll);
+      updateIconStates();
 
-    // Recherche/filter
-    document.getElementById("search").addEventListener("input", applyFilters);
+      document.getElementById("search").addEventListener("input", applyFilters);
 
-    document.getElementById("gridViewBtn").addEventListener("click", () => {
-      if(currentView !== 'cards') {
-        currentView = 'cards';
-        localStorage.setItem('viewMode', currentView);
-        updateIconStates();
-        render();
-      }
-    });
-    document.getElementById("tableViewBtn").addEventListener("click", () => {
-      if(currentView !== 'table') {
-        currentView = 'table';
-        localStorage.setItem('viewMode', currentView);
-        updateIconStates();
-        render();
-      }
-    });
+      document.getElementById("gridViewBtn").addEventListener("click", () => {
+        if(currentView !== 'cards') {
+          currentView = 'cards';
+          localStorage.setItem('viewMode', currentView);
+          updateIconStates();
+          render();
+        }
+      });
+      document.getElementById("tableViewBtn").addEventListener("click", () => {
+        if(currentView !== 'table') {
+          currentView = 'table';
+          localStorage.setItem('viewMode', currentView);
+          updateIconStates();
+          render();
+        }
+      });
+      window.addEventListener('resize', () => {
+        if(currentView === 'table') renderTable();
+      });
+      loadData();
+      window.loadData = loadData;
+    }
+    document.addEventListener('commonLoaded', initPage);
 
     function render() {
       document.getElementById("cards").style.display = currentView === "cards" ? "grid" : "none";
@@ -548,11 +555,3 @@ function handleCardPressLeave(e) {
       });
     }
 
-    // Re-render table on window resize so Unlock column visibility updates
-    window.addEventListener('resize', () => {
-      if(currentView === 'table') renderTable();
-    });
-
-    // Load pictos immediately on startup
-    loadData();
-    window.loadData = loadData;

--- a/src/js/weapons.js
+++ b/src/js/weapons.js
@@ -35,7 +35,7 @@ function updateTranslations() {
 }
 updateTranslations();
 
-document.addEventListener('DOMContentLoaded', () => {
+function initPage(){
   document.getElementById('gridViewBtn').addEventListener('click', () => { if(currentView!=='cards'){currentView='cards';localStorage.setItem('weaponViewMode',currentView);render();updateIconStates();}});
   document.getElementById('tableViewBtn').addEventListener('click', () => { if(currentView!=='table'){currentView='table';localStorage.setItem('weaponViewMode',currentView);render();updateIconStates();}});
   document.getElementById('search').addEventListener('input', applyFilters);
@@ -49,7 +49,8 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('fileInput').addEventListener('change',e=>{if(e.target.files&&e.target.files[0])handleUpload(e.target.files[0]);e.target.value='';});
   initCharacters();
   loadData();
-});
+}
+document.addEventListener('commonLoaded', initPage);
 
 function initCharacters(){
   const div=document.getElementById('charSelect');

--- a/src/weapons.html
+++ b/src/weapons.html
@@ -17,10 +17,6 @@
       <div class="char-select" id="charSelect"></div>
       <div class="actions">
         <div class="icon-bar">
-          <button class="icon-btn" id="downloadBtn" data-i18n-title="download" title="Download"><i class="fa-solid fa-download"></i></button>
-          <button class="icon-btn" id="uploadBtn" data-i18n-title="upload" title="Upload"><i class="fa-solid fa-upload"></i></button>
-          <button class="icon-btn" id="saveBtn" data-i18n-title="save" title="Sauvegarder"><i class="fa-solid fa-floppy-disk"></i></button>
-          <div class="icon-sep"></div>
           <button class="icon-btn toggle" id="hideOwnedBtn" data-i18n-title="hide_owned" title="Hide owned"><i class="fa-solid fa-lock"></i></button>
           <button class="icon-btn toggle" id="hideMissingBtn" data-i18n-title="hide_missing" title="Hide missing"><i class="fa-solid fa-ghost"></i></button>
           <div class="icon-sep"></div>


### PR DESCRIPTION
## Summary
- place Download/Upload/Save actions in the header
- show png icons for action buttons
- adjust language flag styles
- initialize page scripts after header loads

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b5238f894832c824be411ec563966