### PR TITLE
Remove outdated border image

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -440,16 +440,6 @@ body[data-page="weapons"] .card-back {
     padding: 28px 0 18px;
   }
 
-  footer::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 25px;
-    background: url('../resources/images/background_border.png') repeat-x top;
-    z-index: -1;
-  }
 
   .navbar {
     position: fixed;
@@ -466,16 +456,6 @@ body[data-page="weapons"] .card-back {
     font-size: 2rem;
   }
 
-  .navbar::after {
-    content: '';
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    height: 25px;
-    background: url('../resources/images/background_border.png') repeat-x bottom;
-    z-index: 1;
-  }
 
 .navbar .header-inner {
     display: flex;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -521,25 +521,25 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 }
 
 .frame-top {
-  top: 120px;
+  top: 175px;
   transform: translateY(-50%);
   z-index: 3001;
 }
 
 .separator-top {
-  top: 120px;
+  top: 150px;
   transform: translateY(-50%);
   z-index: 3002;
 }
 
 .frame-bottom {
-  bottom: 80px;
+  bottom: 35px;
   transform: translateY(50%);
   z-index: 3001;
 }
 
 .separator-bottom {
-  bottom: 80px;
+  bottom: 58px;
   transform: translateY(50%);
   z-index: 3002;
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -514,7 +514,32 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 
 .section-frame, .section-separator {
   pointer-events: none;
-  display: block;
+  position: fixed;
+  left: 0;
   width: 100%;
+  display: block;
+}
 
+.frame-top {
+  top: 120px;
+  transform: translateY(-50%);
+  z-index: 3001;
+}
+
+.separator-top {
+  top: 120px;
+  transform: translateY(-50%);
+  z-index: 3002;
+}
+
+.frame-bottom {
+  bottom: 80px;
+  transform: translateY(50%);
+  z-index: 3001;
+}
+
+.separator-bottom {
+  bottom: 80px;
+  transform: translateY(50%);
+  z-index: 3002;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -12,8 +12,8 @@
 </head>
 <body class="d-flex flex-column min-vh-100" data-page="pictos">
   <div id="header"></div>
-  <img class="section-frame" src="resources/images/general/frame_horizontal.webp" alt="">
-  <img class="section-separator" src="resources/images/general/separator_horizontal.png" alt="">
+  <img class="section-frame frame-top" src="resources/images/general/frame_horizontal.png" alt="">
+  <img class="section-separator separator-top" src="resources/images/general/separator_horizontal.png" alt="">
   <main class="content-wrapper mt-4 flex-grow-1">
       <h1 data-i18n="heading_pictos">Pictos inventory</h1>
       <div class="actions">
@@ -36,8 +36,8 @@
       <div id="modal" class="modal" style="display:none"><div class="modal-content"></div></div>
       <div id="notificationContainer" class="notification-container"></div>
   </main>
-  <img class="section-frame" src="resources/images/general/frame_horizontal.webp" alt="">
-  <img class="section-separator" src="resources/images/general/separator_horizontal.png" alt="">
+  <img class="section-frame frame-bottom" src="resources/images/general/frame_horizontal.png" alt="">
+  <img class="section-separator separator-bottom" src="resources/images/general/separator_horizontal.png" alt="">
   <div id="footer"></div>
   <script src="js/i18n.js"></script>
   <script src="js/script.js"></script>

--- a/src/weapons.html
+++ b/src/weapons.html
@@ -12,8 +12,8 @@
 </head>
 <body class="d-flex flex-column min-vh-100" data-page="weapons">
   <div id="header"></div>
-  <img class="section-frame" src="resources/images/general/frame_horizontal.webp" alt="">
-  <img class="section-separator" src="resources/images/general/separator_horizontal.png" alt="">
+  <img class="section-frame frame-top" src="resources/images/general/frame_horizontal.png" alt="">
+  <img class="section-separator separator-top" src="resources/images/general/separator_horizontal.png" alt="">
   <main class="content-wrapper mt-4 flex-grow-1">
       <h1 data-i18n="heading_weapons">Weapons inventory</h1>
       <div class="char-select" id="charSelect"></div>
@@ -36,8 +36,8 @@
       <div id="table" class="table-view" style="display:none"></div>
       <div id="notificationContainer" class="notification-container"></div>
   </main>
-  <img class="section-frame" src="resources/images/general/frame_horizontal.webp" alt="">
-  <img class="section-separator" src="resources/images/general/separator_horizontal.png" alt="">
+  <img class="section-frame frame-bottom" src="resources/images/general/frame_horizontal.png" alt="">
+  <img class="section-separator separator-bottom" src="resources/images/general/separator_horizontal.png" alt="">
   <div id="footer"></div>
   <script src="js/i18n.js"></script>
   <script src="js/weapons.js"></script>


### PR DESCRIPTION
## Summary
- drop navbar and footer CSS that referenced `background_border.png`
- `background_border.png` was removed earlier and is replaced by new separators

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b5d08d5dc832cb29cfea412abd97d