### PR TITLE
Unify local data handling across pages

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -40,6 +40,7 @@
   <img class="section-separator separator-bottom" src="resources/images/general/separator_horizontal.png" alt="">
   <div id="footer"></div>
   <script src="js/i18n.js"></script>
+  <script src="js/siteStorage.js"></script>
   <script src="js/script.js"></script>
   <script src="js/common.js"></script>
 </body>

--- a/src/js/siteStorage.js
+++ b/src/js/siteStorage.js
@@ -1,0 +1,62 @@
+let siteData = { pictos: [], weapons: [] };
+
+function loadSiteData() {
+  const saved = localStorage.getItem('siteData');
+  if(saved) {
+    try { siteData = JSON.parse(saved); }
+    catch(e) { siteData = { pictos: [], weapons: [] }; }
+  }
+}
+
+function getSavedItems(key) {
+  const arr = siteData[key];
+  return Array.isArray(arr) ? arr : [];
+}
+
+function setSavedItems(key, arr) {
+  siteData[key] = Array.from(new Set(arr));
+}
+
+function saveSiteData() {
+  localStorage.setItem('siteData', JSON.stringify(siteData));
+}
+
+function downloadSiteData() {
+  const data = JSON.stringify(siteData, null, 2);
+  const blob = new Blob([data], {type:'application/json'});
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'clairObscurData.json';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+function handleSiteUpload(file) {
+  const reader = new FileReader();
+  reader.onload = e => {
+    try {
+      const obj = JSON.parse(e.target.result);
+      if(Array.isArray(obj)) {
+        siteData.pictos = obj;
+      } else if(obj && typeof obj === 'object') {
+        if(Array.isArray(obj.pictos)) siteData.pictos = obj.pictos;
+        if(Array.isArray(obj.weapons)) siteData.weapons = obj.weapons;
+      }
+      if(typeof onSiteDataUpdated === 'function') onSiteDataUpdated();
+    } catch(err) {
+      /* ignore */
+    }
+  };
+  reader.readAsText(file);
+}
+
+document.addEventListener('DOMContentLoaded', loadSiteData);
+
+window.getSavedItems = getSavedItems;
+window.setSavedItems = setSavedItems;
+window.saveSiteData = saveSiteData;
+window.downloadSiteData = downloadSiteData;
+window.handleSiteUpload = handleSiteUpload;

--- a/src/js/siteStorage.js
+++ b/src/js/siteStorage.js
@@ -15,6 +15,7 @@ function getSavedItems(key) {
 
 function setSavedItems(key, arr) {
   siteData[key] = Array.from(new Set(arr));
+  saveSiteData();
 }
 
 function saveSiteData() {
@@ -54,6 +55,7 @@ function handleSiteUpload(file) {
 }
 
 document.addEventListener('DOMContentLoaded', loadSiteData);
+window.addEventListener('beforeunload', saveSiteData);
 
 window.getSavedItems = getSavedItems;
 window.setSavedItems = setSavedItems;

--- a/src/weapons.html
+++ b/src/weapons.html
@@ -40,6 +40,7 @@
   <img class="section-separator separator-bottom" src="resources/images/general/separator_horizontal.png" alt="">
   <div id="footer"></div>
   <script src="js/i18n.js"></script>
+  <script src="js/siteStorage.js"></script>
   <script src="js/weapons.js"></script>
   <script src="js/common.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- centralize site data in `siteStorage.js`
- load site data on each page
- save selections globally for pictos and weapons
- download/upload the combined data file

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b8a3ac730832c8a05f81f4e75dfd1