### PR TITLE
Fix script scope collisions

### DIFF
--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -1,5 +1,5 @@
 const {useEffect} = React;
-const {BrowserRouter, Routes, Route, Navigate, NavLink} = ReactRouterDOM;
+const {BrowserRouter, Routes, Route, Navigate} = ReactRouterDOM;
 
 function Home(){
   useEffect(() => {
@@ -19,7 +19,7 @@ function Home(){
 function PictosPage(){
   useEffect(() => {
     document.body.dataset.page="pictos";
-    if(window.initPictosPage) window.initPictosPage();
+    if(window.pictosPage?.initPage) window.pictosPage.initPage();
     if(window.bindLangEvents) window.bindLangEvents();
     if(window.applyTranslations) window.applyTranslations();
     if(window.updateFlagState) window.updateFlagState();
@@ -59,7 +59,7 @@ function PictosPage(){
 function WeaponsPage(){
   useEffect(() => {
     document.body.dataset.page="weapons";
-    if(window.initWeaponsPage) window.initWeaponsPage();
+    if(window.weaponsPage?.initPage) window.weaponsPage.initPage();
     if(window.bindLangEvents) window.bindLangEvents();
     if(window.applyTranslations) window.applyTranslations();
     if(window.updateFlagState) window.updateFlagState();

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -18,9 +18,12 @@ async function loadLang(lang) {
   document.documentElement.lang = lang;
   applyTranslations();
   updateFlagState();
-  if (typeof updateTranslations === 'function') updateTranslations();
-  if (typeof loadData === 'function') loadData();
-  if (typeof render === 'function') render();
+  const pageObj = window[document.body.dataset.page + 'Page'];
+  if(pageObj){
+    if(typeof pageObj.updateTranslations === 'function') pageObj.updateTranslations();
+    if(typeof pageObj.loadData === 'function') pageObj.loadData();
+    if(typeof pageObj.render === 'function') pageObj.render();
+  }
 }
 
 function applyTranslations() {

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -1,4 +1,5 @@
-    const baseDataUrl = "data/picto-dictionnary";
+(() => {
+const baseDataUrl = "data/picto-dictionnary";
 let pictos = [];
 let pictosFiltered = [];
 let myPictosSet = new Set();
@@ -350,9 +351,7 @@ function handleCardPressLeave(e) {
         if(currentView === 'table') renderTable();
       });
       loadData();
-      window.loadData = loadData;
     }
-    window.initPictosPage = initPage;
 
     function render() {
       document.getElementById("cards").style.display = currentView === "cards" ? "grid" : "none";
@@ -431,11 +430,11 @@ function handleCardPressLeave(e) {
           html += `<th></th>`;
         } else if(col.key === "unlock_description") {
           if(showInfoCol) html += `<th><i class="fa-solid fa-circle-info"></i></th>`;
-          else html += `<th onclick="window.sortTableCol(${i})" class="${sortCol===i ? (sortDir==1?'sorted-asc':'sorted-desc') : ''}">${col.label}</th>`;
+          else html += `<th onclick="window.pictosPage.sortTableCol(${i})" class="${sortCol===i ? (sortDir==1?'sorted-asc':'sorted-desc') : ''}">${col.label}</th>`;
         } else if((col.key === "region" || col.key === "level") && hideInfo) {
           /* skip */
         } else {
-          html += `<th onclick="window.sortTableCol(${i})" class="${sortCol===i ? (sortDir==1?'sorted-asc':'sorted-desc') : ''}">${col.label}</th>`;
+          html += `<th onclick="window.pictosPage.sortTableCol(${i})" class="${sortCol===i ? (sortDir==1?'sorted-asc':'sorted-desc') : ''}">${col.label}</th>`;
         }
       });
       html += `</tr></thead><tbody>`;
@@ -497,10 +496,8 @@ function handleCardPressLeave(e) {
       applyFilters();
     }
 
-    window.onSiteDataUpdated = onSiteDataUpdated;
-
     // Tri tableau (accessible depuis onClick HTML, pour compatibilité file://)
-    window.sortTableCol = function(idx) {
+    function sortTableCol(idx) {
       // Pour les colonnes bonus_picto, tri descendant par défaut (sortDir = -1)
       if(["defense","speed","critical-luck","health"].includes(tableCols[idx].key)) {
         if(sortCol === idx) sortDir = -sortDir;
@@ -535,4 +532,7 @@ function handleCardPressLeave(e) {
         if(i===sortCol) th.classList.add(sortDir===1 ? "sorted-asc":"sorted-desc");
       });
     }
+
+    window.pictosPage = { initPage, updateTranslations, loadData, render, onSiteDataUpdated, sortTableCol };
+})();
 

--- a/src/js/siteStorage.js
+++ b/src/js/siteStorage.js
@@ -46,7 +46,14 @@ function handleSiteUpload(file) {
         if(Array.isArray(obj.pictos)) siteData.pictos = obj.pictos;
         if(Array.isArray(obj.weapons)) siteData.weapons = obj.weapons;
       }
-      if(typeof onSiteDataUpdated === 'function') onSiteDataUpdated();
+      const page = document.body.dataset.page;
+      if(page==='pictos' && window.pictosPage?.onSiteDataUpdated) {
+        window.pictosPage.onSiteDataUpdated();
+      } else if(page==='weapons' && window.weaponsPage?.onSiteDataUpdated) {
+        window.weaponsPage.onSiteDataUpdated();
+      } else if(typeof onSiteDataUpdated === 'function') {
+        onSiteDataUpdated();
+      }
     } catch(err) {
       /* ignore */
     }

--- a/src/js/weapons.js
+++ b/src/js/weapons.js
@@ -1,3 +1,4 @@
+(() => {
 const baseDataUrl = 'data/armes-dictionnary';
 const characters = ['Gustave','Maelle','Lune','Sciel','Verso','Monoco'];
 const damageIcons={
@@ -49,7 +50,6 @@ function initPage(){
   initCharacters();
   loadData();
 }
-window.initWeaponsPage = initPage;
 
 function initCharacters(){
   const div=document.getElementById('charSelect');
@@ -152,7 +152,7 @@ function renderCards(){
 function renderTable(){
   const div=document.getElementById('table');
   let html='<table><thead><tr>';
-  tableCols.forEach((col,i)=>{ html+=`<th onclick="sortTableCol(${i})" class="${sortCol===i?(sortDir===1?'sorted-asc':'sorted-desc'):''}">${col.label}</th>`;});
+  tableCols.forEach((col,i)=>{ html+=`<th onclick=\"window.weaponsPage.sortTableCol(${i})\" class=\"${sortCol===i?(sortDir===1?'sorted-asc':'sorted-desc'):''}\">${col.label}</th>`;});
   html+='</tr></thead><tbody>';
   filteredWeapons.forEach(w=>{
     html+=`<tr data-id="${w.id}"${myWeapons.has(w.id)?' class="owned"':''}>`;
@@ -202,6 +202,5 @@ function onSiteDataUpdated(){
   applyFilters();
 }
 
-window.onSiteDataUpdated = onSiteDataUpdated;
-
-window.sortTableCol=sortTableCol;
+window.weaponsPage = { initPage, updateTranslations, loadData, render, onSiteDataUpdated, sortTableCol };
+})();


### PR DESCRIPTION
## Summary
- avoid global name clashes by namespacing page scripts
- update language logic to call page-specific handlers
- adjust site data updater accordingly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687bce2a8150832cbb648c75ffcc4ea4