### PR TITLE
Update 404 page with merchant backpack image

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -663,6 +663,6 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 }
 
 .not-found-img {
-  max-width: 100%;
   max-height: 60vh;
+  width: auto;
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -661,3 +661,8 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 .modal-option:last-child {
   border-bottom: none;
 }
+
+.not-found-img {
+  max-width: 100%;
+  max-height: 60vh;
+}

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -304,7 +304,10 @@ function NotFound(){
   }, []);
   return (
     <main className="content-wrapper mt-4 flex-grow-1">
-      <h1>404 - Not Found</h1>
+      <div className="d-flex flex-column align-items-center">
+        <img src="resources/images/general/404.png" alt="Merchant backpack" className="img-fluid not-found-img mb-3"/>
+        <p className="lead text-center">Oups ! Le marchand a encore disparu. Seul son sac — introuvable comme d'habitude — est resté.</p>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add humorous text on the 404 page
- display the newly added merchant backpack image
- limit 404 image height so the text remains visible

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687c34eda8f0832c8cae2ea35cb0abed