### PR TITLE
Simplify 404 text and update styling

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -663,8 +663,7 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 }
 
 .not-found-img {
-  max-height: 60vh;
-  max-width: 100%;
-  height: auto;
-  width: auto;
+  max-height: 30vh;
+  max-width: 30vh;
+  margin: auto;
 }

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -306,7 +306,7 @@ function NotFound(){
     <main className="content-wrapper mt-4 flex-grow-1">
       <div className="d-flex flex-column align-items-center">
         <img src="resources/images/general/404.png" alt="Merchant backpack" className="not-found-img mb-3"/>
-        <p className="lead text-center">Oups ! Le marchand a encore disparu. Seul son sac — introuvable comme d'habitude — est resté.</p>
+        <p className="lead text-center">Oops...</p>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- downsize `.not-found-img` style
- replace 404 page text with simpler "Oops..."

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687c425818e4832c9da2092228eaa933