### PR TITLE
Improve team builder layout and rules

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -646,7 +646,8 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   color: #e0e0ff;
 }
 .build-col {
-  flex: 0 0 30%;
+  width: 25vw;
+  margin: auto;
   min-width: 200px;
   border: none;
   padding: 35px;
@@ -670,6 +671,7 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   align-items: center;
   gap: 8px;
   margin-bottom: 6px;
+  margin-top: 2vw;
 }
 .weapon-box {
   flex: 0 0 50%;
@@ -773,6 +775,7 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   grid-template-columns: repeat(2, 1fr);
   gap: 2px 8px;
   margin-bottom: 6px;
+  text-align: center;
 }
 .stats div {
   font-size: 1.1em;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -772,6 +772,11 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 .modal-option:last-child {
   border-bottom: none;
 }
+.modal-options {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 4px 12px;
+}
 
 .not-found-img {
   max-height: 30vh;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -774,7 +774,7 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 }
 .modal-options {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: 4px 12px;
 }
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -752,7 +752,12 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   margin-bottom: 6px;
 }
 .stats div {
+  font-size: 1.1em;
+}
+
+.weapon-buff {
   font-size: 0.9em;
+  margin-bottom: 6px;
 }
 .modal-option {
   padding: 4px 6px;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -665,6 +665,13 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   gap: 8px;
   margin-bottom: 6px;
 }
+.weapon-box {
+  flex: 0 0 50%;
+  width: 50%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
 .char-img,
 .char-add {
   flex: 0 0 50%;
@@ -704,8 +711,7 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   transition: transform 0.2s, opacity 0.2s;
 }
 .weapon-add {
-  flex: 0 0 50%;
-  width: 50%;
+  width: 100%;
 }
 .weapon-add:hover,
 .picto-add:hover {
@@ -718,8 +724,7 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   margin-bottom: 0;
 }
 .weapon-name {
-  flex: 0 0 50%;
-  width: 50%;
+  width: 100%;
   color: #CDB48E;
   cursor: pointer;
   text-align: center;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -621,7 +621,17 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 .team-builder {
   display: flex;
   gap: 20px;
+}
+.team-builder .main-team,
+.team-builder .secondary-team {
+  display: flex;
+  gap: 20px;
   flex-wrap: wrap;
+}
+.team-builder .secondary-team {
+  border-left: 2px solid #555;
+  padding-left: 20px;
+  margin-left: 20px;
 }
 .build-col {
   flex: 1;
@@ -648,6 +658,12 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 .weapon-detail,
 .picto-detail {
   font-size: 0.9em;
+  margin-bottom: 6px;
+}
+.stats {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 2px 8px;
   margin-bottom: 6px;
 }
 .stats div {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -633,6 +633,13 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   padding-left: 20px;
   margin-left: 20px;
 }
+.team-title {
+  width: 100%;
+  margin-top: 0;
+  margin-bottom: 10px;
+  font-family: 'Cinzel', serif;
+  color: #e0e0ff;
+}
 .build-col {
   flex: 1;
   min-width: 200px;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -751,6 +751,18 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 .picto-name:hover {
   transform: scale(1.1);
 }
+.lumina-trigger {
+  display: block;
+  width: 100%;
+  margin-top: 6px;
+  color: #CDB48E;
+  cursor: pointer;
+  text-align: center;
+  transition: transform 0.2s;
+}
+.lumina-trigger:hover {
+  transform: scale(1.1);
+}
 .weapon-detail,
 .picto-detail {
   font-size: 0.9em;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -620,6 +620,7 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 /* Team builder */
 .team-builder {
   display: flex;
+  flex-direction: column;
   gap: 20px;
 }
 .team-builder .main-team,
@@ -629,9 +630,9 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   flex-wrap: wrap;
 }
 .team-builder .secondary-team {
-  border-left: 2px solid #555;
-  padding-left: 20px;
-  margin-left: 20px;
+  border-top: 2px solid #555;
+  padding-top: 20px;
+  margin-top: 20px;
 }
 .team-title {
   width: 100%;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -658,11 +658,36 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   cursor: pointer;
   text-align: center;
 }
-.char-img {
+.char-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.char-img,
+.char-add {
+  flex: 1 1 0;
   width: 100%;
   height: 128px;
+}
+.char-img {
   object-fit: contain;
-  margin-bottom: 6px;
+  cursor: pointer;
+}
+.char-add {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 48px;
+  background: #323846;
+  border: 1px dashed #555;
+  border-radius: 4px;
+  color: #ccc;
+  cursor: pointer;
+}
+.weapon-btn {
+  flex: 1 1 0;
+  margin-bottom: 0;
 }
 .weapon-detail,
 .picto-detail {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -651,6 +651,8 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   border: none;
   padding: 30px;
   background: url('../resources/images/general/panel_background.avif') center/100% auto no-repeat;
+  display: flex;
+  flex-direction: column;
 }
 .select-btn {
   display: block;
@@ -767,6 +769,9 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 .weapon-buff {
   font-size: 0.9em;
   margin-bottom: 6px;
+}
+.bottom-controls {
+  margin-top: auto;
 }
 .modal-option {
   display: inline-flex;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -646,11 +646,11 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   color: #e0e0ff;
 }
 .build-col {
-  width: 25vw;
+  width: 20vw;
   margin: auto;
   min-width: 200px;
   border: none;
-  padding: 35px;
+  padding: 80px;
   background: url('../resources/images/general/panel_background.avif') top center/100% auto no-repeat;
   display: flex;
   flex-direction: column;
@@ -768,13 +768,13 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 .weapon-detail,
 .picto-detail {
   font-size: 0.9em;
-  margin-bottom: 6px;
+  margin-bottom: 20px;
 }
 .stats {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 2px 8px;
-  margin-bottom: 6px;
+  margin-bottom: 20px;
   text-align: center;
 }
 .stats div {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -404,7 +404,7 @@ body[data-page="weapons"] .card-back {
   background: #23263a;
   padding: 20px;
   border-radius: 10px;
-  max-width: 80%;
+  width: 90%;
   max-height: 80vh;
   overflow: hidden;
   display: flex;
@@ -769,16 +769,15 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   margin-bottom: 6px;
 }
 .modal-option {
+  display: inline-flex;
+  align-items: center;
   padding: 4px 6px;
-  border-bottom: 1px solid #444;
+  border: 1px solid #444;
   cursor: pointer;
 }
-.modal-option:last-child {
-  border-bottom: none;
-}
 .modal-options {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  display: flex;
+  flex-wrap: wrap;
   gap: 4px 12px;
   overflow-y: auto;
   flex: 1 1 auto;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -682,10 +682,11 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   background: url('../resources/images/general/frame_cadre.webp') center/contain no-repeat;
   color: #fff;
   cursor: pointer;
+  opacity: 0.5;
   transition: transform 0.2s, opacity 0.2s;
 }
 .char-add:hover {
-  opacity: 0.5;
+  opacity: 1;
   transform: scale(1.1);
 }
 .weapon-btn {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -405,6 +405,10 @@ body[data-page="weapons"] .card-back {
   padding: 20px;
   border-radius: 10px;
   max-width: 80%;
+  max-height: 80vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 .modal-region {
   font-size: 1.2em;
@@ -776,6 +780,17 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 4px 12px;
+  overflow-y: auto;
+  flex: 1 1 auto;
+}
+
+.modal-filter {
+  position: sticky;
+  top: 0;
+  background: #23263a;
+  margin-bottom: 10px;
+  padding-bottom: 10px;
+  z-index: 1;
 }
 
 .not-found-img {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -716,6 +716,29 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   width: 50%;
   margin-bottom: 0;
 }
+.weapon-name {
+  flex: 0 0 50%;
+  width: 50%;
+  color: #CDB48E;
+  cursor: pointer;
+  text-align: center;
+  transition: transform 0.2s;
+}
+.weapon-name:hover {
+  transform: scale(1.1);
+}
+.picto-name {
+  display: block;
+  width: 100%;
+  margin-bottom: 6px;
+  color: #CDB48E;
+  cursor: pointer;
+  text-align: center;
+  transition: transform 0.2s;
+}
+.picto-name:hover {
+  transform: scale(1.1);
+}
 .weapon-detail,
 .picto-detail {
   font-size: 0.9em;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -774,7 +774,7 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 }
 .modal-options {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 4px 12px;
 }
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -774,7 +774,7 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 }
 .modal-options {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: 4px 12px;
 }
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -679,11 +679,14 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   align-items: center;
   justify-content: center;
   font-size: 48px;
-  background: #323846;
-  border: 1px dashed #555;
-  border-radius: 4px;
-  color: #ccc;
+  background: url('../resources/images/general/frame_cadre.webp') center/contain no-repeat;
+  color: #fff;
   cursor: pointer;
+  transition: transform 0.2s, opacity 0.2s;
+}
+.char-add:hover {
+  opacity: 0.5;
+  transform: scale(1.1);
 }
 .weapon-btn {
   flex: 1 1 0;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -649,8 +649,8 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   flex: 0 0 30%;
   min-width: 200px;
   border: none;
-  padding: 30px;
-  background: url('../resources/images/general/panel_background.avif') center/100% auto no-repeat;
+  padding: 35px;
+  background: url('../resources/images/general/panel_background.avif') top center/100% auto no-repeat;
   display: flex;
   flex-direction: column;
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -642,7 +642,7 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   color: #e0e0ff;
 }
 .build-col {
-  flex: 1;
+  flex: 0 0 30%;
   min-width: 200px;
   border: 1px solid #555;
   padding: 10px;
@@ -660,7 +660,8 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 }
 .char-img {
   width: 100%;
-  height: auto;
+  height: 128px;
+  object-fit: contain;
   margin-bottom: 6px;
 }
 .weapon-detail,

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -644,8 +644,9 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 .build-col {
   flex: 0 0 30%;
   min-width: 200px;
-  border: 1px solid #555;
-  padding: 10px;
+  border: none;
+  padding: 30px;
+  background: url('../resources/images/general/panel_background.avif') center/100% auto no-repeat;
 }
 .select-btn {
   display: block;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -666,8 +666,8 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 }
 .char-img,
 .char-add {
-  flex: 1 1 0;
-  width: 100%;
+  flex: 0 0 50%;
+  width: 50%;
   height: 128px;
 }
 .char-img {
@@ -694,7 +694,6 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 100%;
   min-height: 40px;
   margin-bottom: 6px;
   background: url('../resources/images/general/frame_horizontal.webp') center/contain no-repeat;
@@ -703,13 +702,18 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   opacity: 0.5;
   transition: transform 0.2s, opacity 0.2s;
 }
+.weapon-add {
+  flex: 0 0 50%;
+  width: 50%;
+}
 .weapon-add:hover,
 .picto-add:hover {
   opacity: 1;
   transform: scale(1.1);
 }
 .weapon-btn {
-  flex: 1 1 0;
+  flex: 0 0 50%;
+  width: 50%;
   margin-bottom: 0;
 }
 .weapon-detail,

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -689,6 +689,25 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   opacity: 1;
   transform: scale(1.1);
 }
+.weapon-add,
+.picto-add {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 40px;
+  margin-bottom: 6px;
+  background: url('../resources/images/general/frame_horizontal.webp') center/contain no-repeat;
+  color: #fff;
+  cursor: pointer;
+  opacity: 0.5;
+  transition: transform 0.2s, opacity 0.2s;
+}
+.weapon-add:hover,
+.picto-add:hover {
+  opacity: 1;
+  transform: scale(1.1);
+}
 .weapon-btn {
   flex: 1 1 0;
   margin-bottom: 0;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -775,12 +775,35 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   border: 1px solid #444;
   cursor: pointer;
 }
+.modal-option input:checked + span {
+  color: #fffff0;
+}
 .modal-options {
   display: flex;
   flex-wrap: wrap;
   gap: 4px 12px;
   overflow-y: auto;
   flex: 1 1 auto;
+}
+
+.modal-actions {
+  margin-top: 10px;
+  text-align: center;
+}
+.modal-save-btn {
+  background: #23263a;
+  color: #b6e4ff;
+  border: 1px solid #3d4769;
+  padding: 8px 18px;
+  border-radius: 9px;
+  font-size: 1.08em;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.16s, color 0.18s;
+}
+.modal-save-btn:hover {
+  background: #2c3142;
+  color: #fff;
 }
 
 .modal-filter {

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -276,11 +276,15 @@ function BuildPage(){
                   {col.character
                     ? <img className="char-img" src={`resources/images/characters/${col.character.toLowerCase()}.avif`} alt="" onClick={()=>openCharModal(cidx)}/>
                     : <div className="char-add" onClick={()=>openCharModal(cidx)}>+</div>}
-                  {col.weapon
-                    ? <span className="weapon-name" onClick={()=>openWeaponModal(cidx)}>{col.weapon}</span>
-                    : <div className="weapon-add" onClick={()=>openWeaponModal(cidx)}>Arme</div>}
+                  <div className="weapon-box">
+                    {col.weapon
+                      ? <span className="weapon-name" onClick={()=>openWeaponModal(cidx)}>{col.weapon}</span>
+                      : <div className="weapon-add" onClick={()=>openWeaponModal(cidx)}>Arme</div>}
+                    <div className="weapon-buff">
+                      {w ? (buffs.length>0 ? `${t('damage_buff')}: ${buffs.map(b=>t(b)).join(', ')}` : '') : t('no_weapon')}
+                    </div>
+                  </div>
                 </div>
-                {buffs.length>0 && <div className="weapon-buff">{t('damage_buff')}: {buffs.map(b=>t(b)).join(', ')}</div>}
                 <div className="stats">
                   <div>{t('defense')}: {stats.def}</div>
                   <div>{t('speed')}: {stats.speed}</div>
@@ -319,11 +323,15 @@ function BuildPage(){
                   {col.character
                       ? <img className="char-img" src={`resources/images/characters/${col.character.toLowerCase()}.avif`} alt="" onClick={()=>openCharModal(idx)}/>
                       : <div className="char-add" onClick={()=>openCharModal(idx)}>+</div>}
+                    <div className="weapon-box">
                     {col.weapon
                       ? <span className="weapon-name" onClick={()=>openWeaponModal(idx)}>{col.weapon}</span>
                       : <div className="weapon-add" onClick={()=>openWeaponModal(idx)}>Arme</div>}
+                    <div className="weapon-buff">
+                      {w ? (buffs.length>0 ? `${t('damage_buff')}: ${buffs.map(b=>t(b)).join(', ')}` : '') : t('no_weapon')}
+                    </div>
+                    </div>
                   </div>
-                  {buffs.length>0 && <div className="weapon-buff">{t('damage_buff')}: {buffs.map(b=>t(b)).join(', ')}</div>}
                   <div className="stats">
                     <div>{t('defense')}: {stats.def}</div>
                     <div>{t('speed')}: {stats.speed}</div>

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -318,6 +318,19 @@ function BuildPage(){
     });
   }
 
+  function countAvailableSubs(idx){
+    const locked = team[idx].mainPictos.filter(Boolean);
+    const othersLocked = team
+      .flatMap((c, i) => (i === idx ? [] : c.mainPictos))
+      .filter(Boolean);
+    return (
+      locked.length +
+      pictos.filter(
+        p => !locked.includes(p.id) && othersLocked.indexOf(p.id) === -1
+      ).length
+    );
+  }
+
   function copyShare(){
     const data=btoa(JSON.stringify(team));
     const url=`${window.location.origin}/build?data=${encodeURIComponent(data)}`;
@@ -371,7 +384,12 @@ function BuildPage(){
                       </div>
                     ))}
                   </div>
-                  <span className="select-btn" onClick={()=>openSubsModal(cidx)}>{t('choose_luminas')}</span>
+                  <span
+                    className="lumina-trigger"
+                    onClick={() => openSubsModal(cidx)}
+                  >
+                    {t('luminas_label')}: {col.subPictos.length} / {countAvailableSubs(cidx)}
+                  </span>
                 </div>
               </div>
               );
@@ -417,7 +435,12 @@ function BuildPage(){
                           </div>
                         ))}
                       </div>
-                      <span className="select-btn" onClick={()=>openSubsModal(idx)}>{t('choose_luminas')}</span>
+                      <span
+                        className="lumina-trigger"
+                        onClick={() => openSubsModal(idx)}
+                      >
+                        {t('luminas_label')}: {col.subPictos.length} / {countAvailableSubs(idx)}
+                      </span>
                     </div>
                 </div>
               );

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -269,8 +269,12 @@ function BuildPage(){
               const buffs=w?.damage_buff||[];
               return (
               <div className="build-col" key={cidx}>
-                {col.character && <img className="char-img" src={`resources/images/characters/${col.character.toLowerCase()}.avif`} alt=""/>}
-                <span className="select-btn" onClick={()=>openCharModal(cidx)}>{col.character||t('choose_character')}</span>
+                <div className="char-head">
+                  {col.character
+                    ? <img className="char-img" src={`resources/images/characters/${col.character.toLowerCase()}.avif`} alt="" onClick={()=>openCharModal(cidx)}/>
+                    : <div className="char-add" onClick={()=>openCharModal(cidx)}>+</div>}
+                  <span className="select-btn weapon-btn" onClick={()=>openWeaponModal(cidx)}>{col.weapon||t('choose_weapon')}</span>
+                </div>
                 <div className="stats">
                   <div>{t('defense')}: {stats.def}</div>
                   <div>{t('speed')}: {stats.speed}</div>
@@ -278,7 +282,6 @@ function BuildPage(){
                   <div>{t('health')}: {stats.health}</div>
                   {buffs.length>0&&<div>{t('damage_buff')}: {buffs.map(b=>t(b)).join(', ')}</div>}
                 </div>
-                <span className="select-btn" onClick={()=>openWeaponModal(cidx)}>{col.weapon||t('choose_weapon')}</span>
                 {w && <div className="weapon-detail">{w.weapon_effect}</div>}
                 <div className="mains">
                   {col.mainPictos.map((pid,pidx)=>(
@@ -306,8 +309,12 @@ function BuildPage(){
               const idx=cidx+3;
               return (
                 <div className="build-col" key={idx}>
-                  {col.character && <img className="char-img" src={`resources/images/characters/${col.character.toLowerCase()}.avif`} alt=""/>}
-                  <span className="select-btn" onClick={()=>openCharModal(idx)}>{col.character||t('choose_character')}</span>
+                  <div className="char-head">
+                    {col.character
+                      ? <img className="char-img" src={`resources/images/characters/${col.character.toLowerCase()}.avif`} alt="" onClick={()=>openCharModal(idx)}/>
+                      : <div className="char-add" onClick={()=>openCharModal(idx)}>+</div>}
+                    <span className="select-btn weapon-btn" onClick={()=>openWeaponModal(idx)}>{col.weapon||t('choose_weapon')}</span>
+                  </div>
                   <div className="stats">
                     <div>{t('defense')}: {stats.def}</div>
                     <div>{t('speed')}: {stats.speed}</div>
@@ -315,7 +322,6 @@ function BuildPage(){
                     <div>{t('health')}: {stats.health}</div>
                     {buffs.length>0&&<div>{t('damage_buff')}: {buffs.map(b=>t(b)).join(', ')}</div>}
                   </div>
-                  <span className="select-btn" onClick={()=>openWeaponModal(idx)}>{col.weapon||t('choose_weapon')}</span>
                   {w && <div className="weapon-detail">{w.weapon_effect}</div>}
                   <div className="mains">
                     {col.mainPictos.map((pid,pidx)=>(

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -274,7 +274,7 @@ function BuildPage(){
                     ? <img className="char-img" src={`resources/images/characters/${col.character.toLowerCase()}.avif`} alt="" onClick={()=>openCharModal(cidx)}/>
                     : <div className="char-add" onClick={()=>openCharModal(cidx)}>+</div>}
                   {col.weapon
-                    ? <span className="select-btn weapon-btn" onClick={()=>openWeaponModal(cidx)}>{col.weapon}</span>
+                    ? <span className="weapon-name" onClick={()=>openWeaponModal(cidx)}>{col.weapon}</span>
                     : <div className="weapon-add" onClick={()=>openWeaponModal(cidx)}>Arme</div>}
                 </div>
                 <div className="stats">
@@ -289,7 +289,7 @@ function BuildPage(){
                   {col.mainPictos.map((pid,pidx)=>(
                     <div key={pidx}>
                       {pid
-                        ? <span className="select-btn" onClick={()=>openMainModal(cidx,pidx)}>{pictos.find(pc=>pc.id===pid)?.name}</span>
+                        ? <span className="picto-name" onClick={()=>openMainModal(cidx,pidx)}>{pictos.find(pc=>pc.id===pid)?.name}</span>
                         : <div className="picto-add" onClick={()=>openMainModal(cidx,pidx)}>Picto</div>}
                       {pid && (()=>{const p=pictos.find(pc=>pc.id===pid);return p?<div className="picto-detail">{Object.entries(p.bonus_picto||{}).map(([k,v])=>`${t(k)}:${v}`).join(' | ')}{p.bonus_lumina?` - ${p.bonus_lumina}`:''}</div>:null;})()}
                     </div>
@@ -318,7 +318,7 @@ function BuildPage(){
                       ? <img className="char-img" src={`resources/images/characters/${col.character.toLowerCase()}.avif`} alt="" onClick={()=>openCharModal(idx)}/>
                       : <div className="char-add" onClick={()=>openCharModal(idx)}>+</div>}
                     {col.weapon
-                      ? <span className="select-btn weapon-btn" onClick={()=>openWeaponModal(idx)}>{col.weapon}</span>
+                      ? <span className="weapon-name" onClick={()=>openWeaponModal(idx)}>{col.weapon}</span>
                       : <div className="weapon-add" onClick={()=>openWeaponModal(idx)}>Arme</div>}
                   </div>
                   <div className="stats">
@@ -333,7 +333,7 @@ function BuildPage(){
                     {col.mainPictos.map((pid,pidx)=>(
                       <div key={pidx}>
                         {pid
-                          ? <span className="select-btn" onClick={()=>openMainModal(idx,pidx)}>{pictos.find(pc=>pc.id===pid)?.name}</span>
+                          ? <span className="picto-name" onClick={()=>openMainModal(idx,pidx)}>{pictos.find(pc=>pc.id===pid)?.name}</span>
                           : <div className="picto-add" onClick={()=>openMainModal(idx,pidx)}>Picto</div>}
                         {pid && (()=>{const p=pictos.find(pc=>pc.id===pid);return p?<div className="picto-detail">{Object.entries(p.bonus_picto||{}).map(([k,v])=>`${t(k)}:${v}`).join(' | ')}{p.bonus_lumina?` - ${p.bonus_lumina}`:''}</div>:null;})()}
                       </div>

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -194,17 +194,28 @@ function BuildPage(){
         <div className="modal-content" onClick={e=>e.stopPropagation()}>
           {multi ? (
             <>
-              {options.map(o=>(
-                <label key={o.value} className="modal-option">
-                  <input type="checkbox" disabled={o.disabled} checked={local.includes(o.value)} onChange={e=>{
-                    const v=o.value;
-                    setLocal(l=>e.target.checked?[...l,v]:l.filter(x=>x!==v));
-                  }}/>
-                  {o.label}
-                </label>
-              ))}
-              <div style={{marginTop:'10px',textAlign:'right'}}>
-                <button className="btn btn-primary" onClick={apply}>{t('save')}</button>
+              <div className="modal-options">
+                {options.map(o => (
+                  <label key={o.value} className="modal-option">
+                    <input
+                      type="checkbox"
+                      disabled={o.disabled}
+                      checked={local.includes(o.value)}
+                      onChange={e => {
+                        const v = o.value;
+                        setLocal(l =>
+                          e.target.checked ? [...l, v] : l.filter(x => x !== v)
+                        );
+                      }}
+                    />
+                    {o.label}
+                  </label>
+                ))}
+              </div>
+              <div style={{ marginTop: '10px', textAlign: 'right' }}>
+                <button className="btn btn-primary" onClick={apply}>
+                  {t('save')}
+                </button>
               </div>
             </>
           ) : (

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -147,12 +147,16 @@ function BuildPage(){
   function changeMain(idx,pidx,val){
     setTeam(t=>{
       const nt=t.map((c,i)=>({...c,mainPictos:[...c.mainPictos],subPictos:[...c.subPictos]}));
+      const oldLocked=t[idx].mainPictos.filter(Boolean);
       nt[idx].mainPictos[pidx]=val||null;
       // remove duplicate main pictos for this character
       nt[idx].mainPictos=nt[idx].mainPictos.map((p,i)=>i!==pidx&&p===val?null:p);
-      // remove from subs if selected there and sync locked luminas
       const locked=nt[idx].mainPictos.filter(Boolean);
-      nt[idx].subPictos=locked.concat(nt[idx].subPictos.filter(s=>locked.indexOf(s)===-1));
+      // sync locked luminas, removing those unlocked
+      nt[idx].subPictos=[
+        ...locked,
+        ...nt[idx].subPictos.filter(s=>!oldLocked.includes(s) && !locked.includes(s))
+      ];
       // enforce unique across team
       for(let i=0;i<nt.length;i++) if(i!==idx){
         nt[i].mainPictos=nt[i].mainPictos.map(p=>p===val?null:p);
@@ -274,7 +278,8 @@ function BuildPage(){
       }),
       ...pictos.filter(p=>!locked.includes(p.id)).map(p=>({value:p.id,label:p.name,desc:p.bonus_lumina}))
     ];
-    setModal({options:opts,onSelect:vals=>changeSubs(idx,vals),multi:true,values:team[idx].subPictos,search:true});
+    const baseValues=[...new Set([...team[idx].subPictos,...locked])];
+    setModal({options:opts,onSelect:vals=>changeSubs(idx,vals),multi:true,values:baseValues,search:true});
   }
 
   function copyShare(){

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -186,16 +186,30 @@ function BuildPage(){
 
   function SelectionModal(){
     if(!modal) return null;
-    const {options,onSelect,multi,values}=modal;
+    const {options,onSelect,multi,values,search}=modal;
     const [local,setLocal]=React.useState(multi?values.slice():values||'');
+    const [term,setTerm]=React.useState('');
+    const list=search?options.filter(o=>{
+      const txt=(o.label+ (o.desc? ' '+o.desc : '')).toLowerCase();
+      return txt.includes(term.toLowerCase());
+    }):options;
     function apply(){ onSelect(local); setModal(null); }
     return (
       <div className="modal" onClick={()=>setModal(null)} id="modalSelect">
         <div className="modal-content" onClick={e=>e.stopPropagation()}>
+          {search && (
+            <input
+              className="searchbar"
+              style={{width:'100%',marginBottom:'10px'}}
+              placeholder={t('filter_placeholder')}
+              value={term}
+              onChange={e=>setTerm(e.target.value)}
+            />
+          )}
           {multi ? (
             <>
               <div className="modal-options">
-                {options.map(o => (
+                {list.map(o => (
                   <label key={o.value} className="modal-option">
                     <input
                       type="checkbox"
@@ -219,7 +233,7 @@ function BuildPage(){
               </div>
             </>
           ) : (
-            options.map(o=>(
+            list.map(o=>(
               <div key={o.value} className="modal-option" onClick={()=>{onSelect(o.value); setModal(null);}}>{o.label}</div>
             ))
           )}
@@ -254,10 +268,13 @@ function BuildPage(){
   function openSubsModal(idx){
     const locked=team[idx].mainPictos.filter(Boolean);
     const opts=[
-      ...locked.map(id=>({value:id,label:pictos.find(p=>p.id===id)?.name||id,disabled:true})),
-      ...pictos.filter(p=>!locked.includes(p.id)).map(p=>({value:p.id,label:p.name}))
+      ...locked.map(id=>{
+        const p=pictos.find(p=>p.id===id);
+        return {value:id,label:p?.name||id,desc:p?.bonus_lumina||'',disabled:true};
+      }),
+      ...pictos.filter(p=>!locked.includes(p.id)).map(p=>({value:p.id,label:p.name,desc:p.bonus_lumina}))
     ];
-    setModal({options:opts,onSelect:vals=>changeSubs(idx,vals),multi:true,values:team[idx].subPictos});
+    setModal({options:opts,onSelect:vals=>changeSubs(idx,vals),multi:true,values:team[idx].subPictos,search:true});
   }
 
   function copyShare(){

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -361,18 +361,17 @@ function BuildPage(){
                   <div>{t('health')}: {stats.health}</div>
                 </div>
                 {w && <div className="weapon-detail">{w.weapon_effect}</div>}
-                <div className="mains">
-                  {col.mainPictos.map((pid,pidx)=>(
-                    <div key={pidx}>
-                      {pid
-                        ? <span className="picto-name" onClick={()=>openMainModal(cidx,pidx)}>{pictos.find(pc=>pc.id===pid)?.name}</span>
-                        : <div className="picto-add" onClick={()=>openMainModal(cidx,pidx)}>Picto</div>}
-                    </div>
-                  ))}
-                </div>
-                <span className="select-btn" onClick={()=>openSubsModal(cidx)}>{t('choose_luminas')}</span>
-                <div className="subs">
-                  {col.subPictos.map(id=>{const p=pictos.find(pc=>pc.id===id);return p?<div key={id}>{p.name}: {p.bonus_lumina||''}</div>:null;})}
+                <div className="bottom-controls">
+                  <div className="mains">
+                    {col.mainPictos.map((pid,pidx)=>(
+                      <div key={pidx}>
+                        {pid
+                          ? <span className="picto-name" onClick={()=>openMainModal(cidx,pidx)}>{pictos.find(pc=>pc.id===pid)?.name}</span>
+                          : <div className="picto-add" onClick={()=>openMainModal(cidx,pidx)}>Picto</div>}
+                      </div>
+                    ))}
+                  </div>
+                  <span className="select-btn" onClick={()=>openSubsModal(cidx)}>{t('choose_luminas')}</span>
                 </div>
               </div>
               );
@@ -408,19 +407,18 @@ function BuildPage(){
                     <div>{t('health')}: {stats.health}</div>
                   </div>
                   {w && <div className="weapon-detail">{w.weapon_effect}</div>}
-                  <div className="mains">
-                    {col.mainPictos.map((pid,pidx)=>(
-                      <div key={pidx}>
-                        {pid
-                          ? <span className="picto-name" onClick={()=>openMainModal(idx,pidx)}>{pictos.find(pc=>pc.id===pid)?.name}</span>
-                          : <div className="picto-add" onClick={()=>openMainModal(idx,pidx)}>Picto</div>}
+                    <div className="bottom-controls">
+                      <div className="mains">
+                        {col.mainPictos.map((pid,pidx)=>(
+                          <div key={pidx}>
+                            {pid
+                              ? <span className="picto-name" onClick={()=>openMainModal(idx,pidx)}>{pictos.find(pc=>pc.id===pid)?.name}</span>
+                              : <div className="picto-add" onClick={()=>openMainModal(idx,pidx)}>Picto</div>}
+                          </div>
+                        ))}
                       </div>
-                    ))}
-                  </div>
-                  <span className="select-btn" onClick={()=>openSubsModal(idx)}>{t('choose_luminas')}</span>
-                  <div className="subs">
-                    {col.subPictos.map(id=>{const p=pictos.find(pc=>pc.id===id);return p?<div key={id}>{p.name}: {p.bonus_lumina||''}</div>:null;})}
-                  </div>
+                      <span className="select-btn" onClick={()=>openSubsModal(idx)}>{t('choose_luminas')}</span>
+                    </div>
                 </div>
               );
             })}

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -241,12 +241,12 @@ function BuildPage(){
                         );
                       }}
                     />
-                    {o.label}
+                    <span>{o.label}</span>
                   </label>
                 ))}
               </div>
-              <div style={{ marginTop: '10px', textAlign: 'right' }}>
-                <button className="btn btn-primary" onClick={apply}>
+              <div className="modal-actions">
+                <button className="modal-save-btn" onClick={apply}>
                   {t('save')}
                 </button>
               </div>

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -273,7 +273,9 @@ function BuildPage(){
                   {col.character
                     ? <img className="char-img" src={`resources/images/characters/${col.character.toLowerCase()}.avif`} alt="" onClick={()=>openCharModal(cidx)}/>
                     : <div className="char-add" onClick={()=>openCharModal(cidx)}>+</div>}
-                  <span className="select-btn weapon-btn" onClick={()=>openWeaponModal(cidx)}>{col.weapon||t('choose_weapon')}</span>
+                  {col.weapon
+                    ? <span className="select-btn weapon-btn" onClick={()=>openWeaponModal(cidx)}>{col.weapon}</span>
+                    : <div className="weapon-add" onClick={()=>openWeaponModal(cidx)}>Arme</div>}
                 </div>
                 <div className="stats">
                   <div>{t('defense')}: {stats.def}</div>
@@ -286,7 +288,9 @@ function BuildPage(){
                 <div className="mains">
                   {col.mainPictos.map((pid,pidx)=>(
                     <div key={pidx}>
-                      <span className="select-btn" onClick={()=>openMainModal(cidx,pidx)}>{pid? pictos.find(pc=>pc.id===pid)?.name : t('choose_picto',{num:pidx+1})}</span>
+                      {pid
+                        ? <span className="select-btn" onClick={()=>openMainModal(cidx,pidx)}>{pictos.find(pc=>pc.id===pid)?.name}</span>
+                        : <div className="picto-add" onClick={()=>openMainModal(cidx,pidx)}>Picto</div>}
                       {pid && (()=>{const p=pictos.find(pc=>pc.id===pid);return p?<div className="picto-detail">{Object.entries(p.bonus_picto||{}).map(([k,v])=>`${t(k)}:${v}`).join(' | ')}{p.bonus_lumina?` - ${p.bonus_lumina}`:''}</div>:null;})()}
                     </div>
                   ))}
@@ -310,10 +314,12 @@ function BuildPage(){
               return (
                 <div className="build-col" key={idx}>
                   <div className="char-head">
-                    {col.character
+                  {col.character
                       ? <img className="char-img" src={`resources/images/characters/${col.character.toLowerCase()}.avif`} alt="" onClick={()=>openCharModal(idx)}/>
                       : <div className="char-add" onClick={()=>openCharModal(idx)}>+</div>}
-                    <span className="select-btn weapon-btn" onClick={()=>openWeaponModal(idx)}>{col.weapon||t('choose_weapon')}</span>
+                    {col.weapon
+                      ? <span className="select-btn weapon-btn" onClick={()=>openWeaponModal(idx)}>{col.weapon}</span>
+                      : <div className="weapon-add" onClick={()=>openWeaponModal(idx)}>Arme</div>}
                   </div>
                   <div className="stats">
                     <div>{t('defense')}: {stats.def}</div>
@@ -326,7 +332,9 @@ function BuildPage(){
                   <div className="mains">
                     {col.mainPictos.map((pid,pidx)=>(
                       <div key={pidx}>
-                        <span className="select-btn" onClick={()=>openMainModal(idx,pidx)}>{pid? pictos.find(pc=>pc.id===pid)?.name : t('choose_picto',{num:pidx+1})}</span>
+                        {pid
+                          ? <span className="select-btn" onClick={()=>openMainModal(idx,pidx)}>{pictos.find(pc=>pc.id===pid)?.name}</span>
+                          : <div className="picto-add" onClick={()=>openMainModal(idx,pidx)}>Picto</div>}
                         {pid && (()=>{const p=pictos.find(pc=>pc.id===pid);return p?<div className="picto-detail">{Object.entries(p.bonus_picto||{}).map(([k,v])=>`${t(k)}:${v}`).join(' | ')}{p.bonus_lumina?` - ${p.bonus_lumina}`:''}</div>:null;})()}
                       </div>
                     ))}

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -218,7 +218,12 @@ function BuildPage(){
   const usedChars=new Set(team.map(t=>t.character).filter(Boolean));
 
   function openCharModal(idx){
-    const opts=characters.filter(ch=>!usedChars.has(ch)||ch===team[idx].character).map(ch=>({value:ch,label:ch}));
+    let opts=characters.filter(ch=>!usedChars.has(ch)||ch===team[idx].character);
+    const hasGustave=team.some((t,i)=>t.character==='Gustave' && i!==idx);
+    const hasVerso=team.some((t,i)=>t.character==='Verso' && i!==idx);
+    if(hasGustave) opts=opts.filter(ch=>ch!=='Verso');
+    if(hasVerso) opts=opts.filter(ch=>ch!=='Gustave');
+    opts=opts.map(ch=>({value:ch,label:ch}));
     setModal({options:opts,onSelect:val=>updateTeam(idx,{character:val,weapon:'',mainPictos:[null,null,null],subPictos:[]})});
   }
   function openWeaponModal(idx){
@@ -255,13 +260,16 @@ function BuildPage(){
           <button className="icon-btn" onClick={copyShare} data-i18n-title="share" title="Share"><i className="fa-solid fa-share-nodes"></i></button>
         </div>
         <div className="team-builder">
-          {team.map((col,cidx)=>{
-            const stats=computeStats(col.mainPictos.filter(Boolean));
-            const charWeapons=weapons.filter(w=>w.character===col.character);
-            const w=charWeapons.find(x=>x.name===col.weapon);
-            const buffs=w?.damage_buff||[];
-            return (
+          <div className="main-team">
+            {team.slice(0,3).map((col,cidx)=>{
+              const stats=computeStats(col.mainPictos.filter(Boolean));
+              const charWeapons=weapons.filter(w=>w.character===col.character);
+              const w=charWeapons.find(x=>x.name===col.weapon);
+              const buffs=w?.damage_buff||[];
+              return (
               <div className="build-col" key={cidx}>
+                {col.character && <img className="char-img" src={`resources/images/characters/${col.character.toLowerCase()}.avif`} alt=""/>}
+                <span className="select-btn" onClick={()=>openCharModal(cidx)}>{col.character||t('choose_character')}</span>
                 <div className="stats">
                   <div>{t('defense')}: {stats.def}</div>
                   <div>{t('speed')}: {stats.speed}</div>
@@ -269,8 +277,6 @@ function BuildPage(){
                   <div>{t('health')}: {stats.health}</div>
                   {buffs.length>0&&<div>{t('damage_buff')}: {buffs.map(b=>t(b)).join(', ')}</div>}
                 </div>
-                <span className="select-btn" onClick={()=>openCharModal(cidx)}>{col.character||t('choose_character')}</span>
-                {col.character && <img className="char-img" src={`resources/images/characters/${col.character.toLowerCase()}.avif`} alt=""/>}
                 <span className="select-btn" onClick={()=>openWeaponModal(cidx)}>{col.weapon||t('choose_weapon')}</span>
                 {w && <div className="weapon-detail">{w.weapon_effect}</div>}
                 <div className="mains">
@@ -286,8 +292,45 @@ function BuildPage(){
                   {col.subPictos.map(id=>{const p=pictos.find(pc=>pc.id===id);return p?<div key={id}>{p.name}: {p.bonus_lumina||''}</div>:null;})}
                 </div>
               </div>
-            );
-          })}
+              );
+            })}
+          </div>
+          <div className="secondary-team">
+            {team.slice(3).map((col,cidx)=>{
+              const stats=computeStats(col.mainPictos.filter(Boolean));
+              const charWeapons=weapons.filter(w=>w.character===col.character);
+              const w=charWeapons.find(x=>x.name===col.weapon);
+              const buffs=w?.damage_buff||[];
+              const idx=cidx+3;
+              return (
+                <div className="build-col" key={idx}>
+                  {col.character && <img className="char-img" src={`resources/images/characters/${col.character.toLowerCase()}.avif`} alt=""/>}
+                  <span className="select-btn" onClick={()=>openCharModal(idx)}>{col.character||t('choose_character')}</span>
+                  <div className="stats">
+                    <div>{t('defense')}: {stats.def}</div>
+                    <div>{t('speed')}: {stats.speed}</div>
+                    <div>{t('critical-luck')}: {stats.crit}</div>
+                    <div>{t('health')}: {stats.health}</div>
+                    {buffs.length>0&&<div>{t('damage_buff')}: {buffs.map(b=>t(b)).join(', ')}</div>}
+                  </div>
+                  <span className="select-btn" onClick={()=>openWeaponModal(idx)}>{col.weapon||t('choose_weapon')}</span>
+                  {w && <div className="weapon-detail">{w.weapon_effect}</div>}
+                  <div className="mains">
+                    {col.mainPictos.map((pid,pidx)=>(
+                      <div key={pidx}>
+                        <span className="select-btn" onClick={()=>openMainModal(idx,pidx)}>{pid? pictos.find(pc=>pc.id===pid)?.name : t('choose_picto',{num:pidx+1})}</span>
+                        {pid && (()=>{const p=pictos.find(pc=>pc.id===pid);return p?<div className="picto-detail">{Object.entries(p.bonus_picto||{}).map(([k,v])=>`${t(k)}:${v}`).join(' | ')}{p.bonus_lumina?` - ${p.bonus_lumina}`:''}</div>:null;})()}
+                      </div>
+                    ))}
+                  </div>
+                  <span className="select-btn" onClick={()=>openSubsModal(idx)}>{t('choose_luminas')}</span>
+                  <div className="subs">
+                    {col.subPictos.map(id=>{const p=pictos.find(pc=>pc.id===id);return p?<div key={id}>{p.name}: {p.bonus_lumina||''}</div>:null;})}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
         </div>
       </main>
       <SelectionModal />

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -252,9 +252,20 @@ function BuildPage(){
               </div>
             </>
           ) : (
-            list.map(o=>(
-              <div key={o.value} className="modal-option" onClick={()=>{onSelect(o.value); setModal(null);}}>{o.label}</div>
-            ))
+            <div className="modal-options">
+              {list.map(o => (
+                <div
+                  key={o.value}
+                  className="modal-option"
+                  onClick={() => {
+                    onSelect(o.value);
+                    setModal(null);
+                  }}
+                >
+                  {o.label}
+                </div>
+              ))}
+            </div>
           )}
         </div>
       </div>
@@ -279,10 +290,18 @@ function BuildPage(){
   }
   function openMainModal(idx,pidx){
     const existing=team[idx].mainPictos.filter((_,i)=>i!==pidx);
-    const available=pictos
-      .filter(p=>(!usedMain.has(p.id) || team[idx].mainPictos.includes(p.id)) && !existing.includes(p.id))
-      .map(p=>({value:p.id,label:p.name}));
-    setModal({options:available,onSelect:val=>changeMain(idx,pidx,val)});
+    const available = pictos
+      .filter(
+        p =>
+          (!usedMain.has(p.id) || team[idx].mainPictos.includes(p.id)) &&
+          !existing.includes(p.id)
+      )
+      .map(p => ({ value: p.id, label: p.name }));
+    setModal({
+      options: available,
+      onSelect: val => changeMain(idx, pidx, val),
+      search: true
+    });
   }
   function openSubsModal(idx){
     const locked = team[idx].mainPictos.filter(Boolean);

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -199,8 +199,8 @@ function BuildPage(){
         <div className="modal-content" onClick={e=>e.stopPropagation()}>
           {search && (
             <input
-              className="searchbar"
-              style={{width:'100%',marginBottom:'10px'}}
+              className="searchbar modal-filter"
+              style={{width:'100%'}}
               placeholder={t('filter_placeholder')}
               value={term}
               onChange={e=>setTerm(e.target.value)}

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -261,6 +261,7 @@ function BuildPage(){
         </div>
         <div className="team-builder">
           <div className="main-team">
+            <h2 className="team-title" data-i18n="main_team">{t('main_team')}</h2>
             {team.slice(0,3).map((col,cidx)=>{
               const stats=computeStats(col.mainPictos.filter(Boolean));
               const charWeapons=weapons.filter(w=>w.character===col.character);
@@ -296,6 +297,7 @@ function BuildPage(){
             })}
           </div>
           <div className="secondary-team">
+            <h2 className="team-title" data-i18n="secondary_team">{t('secondary_team')}</h2>
             {team.slice(3).map((col,cidx)=>{
               const stats=computeStats(col.mainPictos.filter(Boolean));
               const charWeapons=weapons.filter(w=>w.character===col.character);

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -52,6 +52,7 @@
   "link_copied": "Link copied!",
   "main_team": "Main team",
   "secondary_team": "Secondary team",
+  "no_weapon": "No weapon",
   "heading_home": "Welcome",
   "index_desc1": "Browse the full list of pictos and mark those you own. Filter by region or effect to organize your collection and save your progress.",
   "index_desc2": "Track your entire arsenal. Each weapon sheet shows who can wield it and the effects it grants so you never miss a piece of equipment."

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -50,6 +50,8 @@
   "choose_luminas": "Choose luminas",
   "share": "Share",
   "link_copied": "Link copied!",
+  "main_team": "Main team",
+  "secondary_team": "Secondary team",
   "heading_home": "Welcome",
   "index_desc1": "Browse the full list of pictos and mark those you own. Filter by region or effect to organize your collection and save your progress.",
   "index_desc2": "Track your entire arsenal. Each weapon sheet shows who can wield it and the effects it grants so you never miss a piece of equipment."

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -50,6 +50,7 @@
   "choose_luminas": "Choose luminas",
   "share": "Share",
   "link_copied": "Link copied!",
+  "filter_placeholder": "Filter...",
   "main_team": "Main team",
   "secondary_team": "Secondary team",
   "no_weapon": "No weapon",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -48,6 +48,7 @@
   "choose_weapon": "Choose weapon",
   "choose_picto": "Choose picto {num}",
   "choose_luminas": "Choose luminas",
+  "luminas_label": "Luminas",
   "share": "Share",
   "link_copied": "Link copied!",
   "filter_placeholder": "Filter...",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -46,6 +46,8 @@
   "choose_luminas": "Choisir les luminas",
   "share": "Partager",
   "link_copied": "Lien copié !",
+  "main_team": "Équipe principale",
+  "secondary_team": "Équipe secondaire",
   "damage_type": "Type de dégâts",
   "damage_buff": "Bonus",
   "weapon_effect": "Effet",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -48,6 +48,7 @@
   "link_copied": "Lien copié !",
   "main_team": "Équipe principale",
   "secondary_team": "Équipe secondaire",
+  "no_weapon": "Aucune arme",
   "damage_type": "Type de dégâts",
   "damage_buff": "Bonus",
   "weapon_effect": "Effet",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -46,6 +46,7 @@
   "choose_luminas": "Choisir les luminas",
   "share": "Partager",
   "link_copied": "Lien copié !",
+  "filter_placeholder": "Filtrer...",
   "main_team": "Équipe principale",
   "secondary_team": "Équipe secondaire",
   "no_weapon": "Aucune arme",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -44,6 +44,7 @@
   "choose_weapon": "Choisir son arme",
   "choose_picto": "Choisir picto {num}",
   "choose_luminas": "Choisir les luminas",
+  "luminas_label": "Luminas",
   "share": "Partager",
   "link_copied": "Lien copié !",
   "filter_placeholder": "Filtrer...",


### PR DESCRIPTION
## Summary
- rearrange team builder display to show main and secondary teams separately
- place character avatar above the stats and show stats in a 2x2 grid
- prevent Gustave and Verso from being selected together

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687c45ce7ea8832cb3ee06cddb5dc40e