### PR TITLE
Support environment specific config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,26 @@ so everything works from the `dist` folder alone:
 ```bash
 npm run build
 ```
+
+## Configuration
+
+Runtime options are provided by a `config.js` file loaded by the page. Three
+variants are available in `src/`:
+
+- `config.dev.js`
+- `config.rec.js`
+- `config.pro.js`
+
+The build script copies the appropriate file to the distribution directory based
+on the `APP_ENV` environment variable (`dev` by default). After building you can
+still edit `dist/config.js` to adjust the values:
+
+- `clairobscur-api-url`
+- `auth-url`
+- `auth-client-id`
+
+Example for a production build:
+
+```bash
+APP_ENV=pro npm run build
+```

--- a/build.js
+++ b/build.js
@@ -30,6 +30,25 @@ function transpile(srcFile, outFile){
 fs.rmSync(distDir, { recursive: true, force: true });
 copyRecursive(srcDir, distDir);
 
+// select environment configuration
+const appEnv = process.env.APP_ENV || 'dev';
+const envFile = `config.${appEnv}.js`;
+const distEnvPath = path.join(distDir, envFile);
+let finalConfig = path.join(distDir, 'config.js');
+
+if (fs.existsSync(distEnvPath)) {
+  fs.renameSync(distEnvPath, finalConfig);
+} else {
+  const fallback = path.join(distDir, 'config.dev.js');
+  fs.renameSync(fallback, finalConfig);
+}
+
+for (const f of fs.readdirSync(distDir)) {
+  if (/^config\.(dev|rec|pro)\.js$/.test(f) && f !== 'config.js') {
+    fs.rmSync(path.join(distDir, f));
+  }
+}
+
 // transpile JSX files
 transpile(path.join(srcDir, 'js', 'components.jsx'), path.join(distDir, 'js', 'components.js'));
 transpile(path.join(srcDir, 'js', 'app.jsx'), path.join(distDir, 'js', 'app.js'));

--- a/src/config.dev.js
+++ b/src/config.dev.js
@@ -1,0 +1,5 @@
+window.CONFIG = {
+  "clairobscur-api-url": "http://localhost:8000/api",
+  "auth-url": "http://localhost:8000/auth",
+  "auth-client-id": "http://localhost:8000/auth/client-id"
+};

--- a/src/config.pro.js
+++ b/src/config.pro.js
@@ -1,0 +1,5 @@
+window.CONFIG = {
+  "clairobscur-api-url": "https://api.example.com",
+  "auth-url": "https://auth.example.com",
+  "auth-client-id": "prod-client-id"
+};

--- a/src/config.rec.js
+++ b/src/config.rec.js
@@ -1,0 +1,5 @@
+window.CONFIG = {
+  "clairobscur-api-url": "https://rec.example.com/api",
+  "auth-url": "https://rec.example.com/auth",
+  "auth-client-id": "rec-client-id"
+};

--- a/src/index.html
+++ b/src/index.html
@@ -18,6 +18,7 @@
 </head>
 <body class="d-flex flex-column min-vh-100">
   <div id="app"></div>
+  <script src="config.js"></script>
   <script type="text/babel" src="js/components.jsx"></script>
   <script type="text/babel" src="js/app.jsx"></script>
   <script src="js/i18n.js"></script>


### PR DESCRIPTION
## Summary
- rename default config to `config.dev.js`
- add `config.rec.js` and `config.pro.js`
- select which config is copied during build via `APP_ENV`
- update README with environment instructions
- rename `auth-client-id-url` to `auth-client-id`

## Testing
- `npm install`
- `npm run build`
- `APP_ENV=rec npm run build`
- `APP_ENV=pro npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687c60ad9adc832caead175a570ce1b6