### PR TITLE
Add admin page for data management

### DIFF
--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -457,6 +457,29 @@ function BuildPage(){
   );
 }
 
+function AdminPage(){
+  const api=window.CONFIG?.["clairobscur-api-url"]||'';
+  useEffect(()=>{
+    document.body.dataset.page='admin';
+    if(window.bindLangEvents) window.bindLangEvents();
+    if(window.applyTranslations) window.applyTranslations();
+    if(window.updateFlagState) window.updateFlagState();
+  },[]);
+  return (
+    <>
+      <img className="section-frame frame-top" src="resources/images/general/frame_horizontal.png" alt=""/>
+      <img className="section-separator separator-top" src="resources/images/general/separator_horizontal.png" alt=""/>
+      <main className="content-wrapper mt-4 flex-grow-1">
+        <h1 data-i18n="heading_admin">Administration</h1>
+        <iframe src={`${api}/admin/pictos`} style={{width:'100%',height:'400px',border:'none',marginBottom:'20px'}} title="Pictos admin"></iframe>
+        <iframe src={`${api}/admin/weapons`} style={{width:'100%',height:'400px',border:'none'}} title="Weapons admin"></iframe>
+      </main>
+      <img className="section-frame frame-bottom" src="resources/images/general/frame_horizontal.png" alt=""/>
+      <img className="section-separator separator-bottom" src="resources/images/general/separator_horizontal.png" alt=""/>
+    </>
+  );
+}
+
 function NotFound(){
   useEffect(() => {
     document.body.dataset.page="404";
@@ -484,6 +507,7 @@ function App(){
         <Route path="/pictos" element={<PictosPage />} />
         <Route path="/weapons" element={<WeaponsPage />} />
         <Route path="/build" element={<BuildPage />} />
+        <Route path="/admin" element={<AdminPage />} />
         <Route path="/404" element={<NotFound />} />
         <Route path="*" element={<Navigate to="/404" replace />} />
       </Routes>

--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -8,15 +8,23 @@ function updateLoginState(authenticated){
     const username=keycloak?.tokenParsed?.preferred_username||'user';
     btn.classList.add('user-name');
     btn.textContent=username;
+    const adminLink=document.getElementById('adminNav');
+    const existing=btn.querySelector('.admin-crown');
+    if(existing) existing.remove();
     if(keycloak.hasResourceRole?.('admin','coh-app')){
       const icon=document.createElement('i');
       icon.className='fa-solid fa-crown admin-crown';
       btn.appendChild(icon);
+      if(adminLink) adminLink.style.display='block';
+    }else{
+      if(adminLink) adminLink.style.display='none';
     }
     btn.dataset.i18nTitle='logout';
     btn.title=t('logout');
     btn.onclick=()=>keycloak.logout();
   }else{
+    const adminLink=document.getElementById('adminNav');
+    if(adminLink) adminLink.style.display='none';
     btn.classList.remove('user-name');
     btn.innerHTML='<i class="fa-solid fa-user"></i>';
     btn.dataset.i18nTitle='login';

--- a/src/js/components.jsx
+++ b/src/js/components.jsx
@@ -8,6 +8,7 @@ const Header = () => (
         <li className="nav-item"><NavLink className="nav-link" to="/pictos" data-i18n="nav_pictos">Pictos inventory</NavLink></li>
         <li className="nav-item"><NavLink className="nav-link" to="/weapons" data-i18n="nav_weapons">Weapons inventory</NavLink></li>
         <li className="nav-item"><NavLink className="nav-link" to="/build" data-i18n="nav_build">Team builder</NavLink></li>
+        <li className="nav-item" id="adminNav" style={{display:'none'}}><NavLink className="nav-link" to="/admin" data-i18n="nav_admin">Admin</NavLink></li>
       </ul>
       <div className="header-right">
         <div className="header-panel">

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -60,5 +60,7 @@
   "index_desc2": "Track your entire arsenal. Each weapon sheet shows who can wield it and the effects it grants so you never miss a piece of equipment.",
   "login": "Login",
   "logout": "Logout",
-  "index_desc3": "Build your team composition and share it with a link."
+  "index_desc3": "Build your team composition and share it with a link.",
+  "nav_admin": "Admin",
+  "heading_admin": "Administration"
 }

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -60,5 +60,7 @@
   "index_desc2": "Suivez l'intégralité de votre arsenal. Chaque fiche d'arme précise qui peut l'utiliser et quels effets elle apporte afin de ne rien manquer.",
   "login": "Connexion",
   "logout": "Déconnexion",
-  "index_desc3": "Créez votre composition d'équipe et partagez-la via un lien."
+  "index_desc3": "Créez votre composition d'équipe et partagez-la via un lien.",
+  "nav_admin": "Admin",
+  "heading_admin": "Administration"
 }


### PR DESCRIPTION
## Summary
- show an Admin link in the header when the user has the `admin` role
- handle admin visibility in auth logic
- implement new `/admin` route displaying API admin pages
- add translations for the new entry

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d450f27e4832ca438fc5e667c1f7f