### PR TITLE
Fix auth header in API calls

### DIFF
--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -136,7 +136,7 @@ function BuildPage(){
     const ref=params.get('refBuild');
     const d=params.get('data');
     if(ref && apiUrl){
-      fetch(`${apiUrl}/public/builds/${encodeURIComponent(ref)}`)
+      apiFetch(`${apiUrl}/public/builds/${encodeURIComponent(ref)}`)
         .then(r=>r.ok?r.json():Promise.reject())
         .then(obj=>{ if(Array.isArray(obj)&&obj.length===5) setTeam(obj); })
         .catch(()=>{});
@@ -344,7 +344,7 @@ function BuildPage(){
 
   function copyShare(){
     if(!apiUrl) return;
-    fetch(`${apiUrl}/public/builds`,{
+    apiFetch(`${apiUrl}/public/builds`,{
       method:'POST',
       headers:{'Content-Type':'application/json'},
       body:JSON.stringify(team)
@@ -484,7 +484,7 @@ function AdminPage(){
 
 
   const loadData = () => {
-    fetch(`${api}/public/data/${currentLang}`).then(r=>r.json()).then(data=>{
+    apiFetch(`${api}/public/data/${currentLang}`).then(r=>r.json()).then(data=>{
       const charRows = [];
       data.characters.forEach(c=>{
         (c.details||[{lang:'',name:'',story:''}]).forEach(d=>{

--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -62,3 +62,14 @@ function initAuth(){
 
 document.addEventListener('DOMContentLoaded',initAuth);
 
+function apiFetch(url, options = {}) {
+  const headers = Object.assign({}, options.headers);
+  const token = window.keycloak?.token;
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return fetch(url, { ...options, headers });
+}
+
+window.apiFetch = apiFetch;
+

--- a/src/js/components.jsx
+++ b/src/js/components.jsx
@@ -57,7 +57,7 @@ function UIGrid({columns, rows, setRows, endpoint, idField}){
     setEditCell(null);
     const method = row.__new ? 'POST' : 'PUT';
     const body = JSON.stringify(row);
-    await fetch(`${api}${endpoint}`, {
+    await apiFetch(`${api}${endpoint}`, {
       method,
       headers:{'Content-Type':'application/json'},
       body
@@ -72,7 +72,7 @@ function UIGrid({columns, rows, setRows, endpoint, idField}){
   const deleteRow = async (rowIndex) => {
     const row = rows[rowIndex];
     setRows(rows.filter((_,i)=>i!==rowIndex));
-    await fetch(`${api}${endpoint}`, {
+    await apiFetch(`${api}${endpoint}`, {
       method:'DELETE',
       headers:{'Content-Type':'application/json'},
       body: JSON.stringify(row)


### PR DESCRIPTION
## Summary
- add `apiFetch` helper that injects the access token
- use `apiFetch` for admin grid and build sharing requests

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687dfb17316c832c9b4c8a67b84228e1