### PR TITLE
Add token refresh

### DIFF
--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -2,7 +2,7 @@ let keycloak = null;
 let refreshTimer = null;
 
 function startTokenRefresh(){
-  if(refreshTimer || !keycloak) return;
+  if(refreshTimer || !keycloak || !keycloak.token) return;
   refreshTimer = setInterval(()=>{
     keycloak.updateToken(60).catch(err=>{
       console.error('Token refresh failed', err);
@@ -83,7 +83,7 @@ function initAuth(){
 document.addEventListener('DOMContentLoaded',initAuth);
 
 async function apiFetch(url, options = {}) {
-  if (window.keycloak) {
+  if (window.keycloak && window.keycloak.token) {
     try {
       await window.keycloak.updateToken(30);
     } catch (e) {

--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -1,10 +1,29 @@
 let keycloak = null;
+let refreshTimer = null;
+
+function startTokenRefresh(){
+  if(refreshTimer || !keycloak) return;
+  refreshTimer = setInterval(()=>{
+    keycloak.updateToken(60).catch(err=>{
+      console.error('Token refresh failed', err);
+      stopTokenRefresh();
+    });
+  }, 30000);
+}
+
+function stopTokenRefresh(){
+  if(refreshTimer){
+    clearInterval(refreshTimer);
+    refreshTimer=null;
+  }
+}
 
 function updateLoginState(authenticated){
   const btn=document.getElementById('loginBtn');
   if(!btn) return;
 
   if(authenticated){
+    startTokenRefresh();
     const username=keycloak?.tokenParsed?.preferred_username||'user';
     btn.classList.add('user-name');
     btn.textContent=username;
@@ -23,6 +42,7 @@ function updateLoginState(authenticated){
     btn.title=t('logout');
     btn.onclick=()=>keycloak.logout();
   }else{
+    stopTokenRefresh();
     const adminLink=document.getElementById('adminNav');
     if(adminLink) adminLink.style.display='none';
     btn.classList.remove('user-name');
@@ -62,7 +82,14 @@ function initAuth(){
 
 document.addEventListener('DOMContentLoaded',initAuth);
 
-function apiFetch(url, options = {}) {
+async function apiFetch(url, options = {}) {
+  if (window.keycloak) {
+    try {
+      await window.keycloak.updateToken(30);
+    } catch (e) {
+      console.error('Token refresh failed before fetch', e);
+    }
+  }
   const headers = Object.assign({}, options.headers);
   const token = window.keycloak?.token;
   if (token) {


### PR DESCRIPTION
## Summary
- implement periodic token refresh on Keycloak login state
- refresh Keycloak token on each api request

## Testing
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_687f624403e0832c9c7f7236e81baee0