### PR TITLE
Improve admin grid layout

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -880,7 +880,12 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 .admin-grid{flex:1;height:85vh;max-height:calc(100vh - 250px);overflow:auto;background:#21232d;}
 .base-row .admin-grid{height:60vh;max-height:calc(100vh - 250px);}
 .admin-grid .MuiDataGrid-root{color:#fff;min-height:100%;}
-.admin-grid .MuiDataGrid-cell,.admin-grid .MuiDataGrid-columnHeader{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.admin-grid .MuiDataGrid-cell,.admin-grid .MuiDataGrid-columnHeader{
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
+  font-size:0.85em;
+}
 .admin-section{margin-top:20px;}
 
 .admin-grid .MuiDataGrid-footerContainer{

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -883,6 +883,13 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 .admin-grid .MuiDataGrid-cell,.admin-grid .MuiDataGrid-columnHeader{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
 .admin-section{margin-top:20px;}
 
+.admin-grid .MuiDataGrid-footerContainer{
+  padding-right:10px;
+}
+.admin-grid .add-row-btn{
+  margin-left:10px;
+}
+
 
 .admin-tabs-nav{display:flex;gap:10px;margin-bottom:20px;}
 .admin-tabs-nav button{flex:1;padding:8px 12px;border:none;background:#333;color:#fff;border-radius:4px;cursor:pointer;}

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -537,6 +537,11 @@ function AdminPage(){
   const [weapons, setWeapons] = React.useState([]);
   const [tab, setTab] = React.useState(0);
 
+  const langOptions = ['fr','en'];
+  const charOptions = React.useMemo(() => Array.from(new Set(characters.map(c => c.idCharacter))), [characters]);
+  const typeOptions = React.useMemo(() => Array.from(new Set(damageTypes.map(t => t.idDamageType))), [damageTypes]);
+  const buffOptions = React.useMemo(() => Array.from(new Set(damageBuffTypes.map(b => b.idDamageBuffType))), [damageBuffTypes]);
+
 
   const loadData = () => {
     getSiteData().then(data=>{
@@ -636,18 +641,18 @@ function AdminPage(){
             <div className="admin-row base-row">
               <UIGrid columns={[
                 {field:'idCharacter',header:'ID', width:80, editable:false},
-                {field:'lang',header:'Lang', width:80},
+                {field:'lang',header:'Lang', width:80, type:'singleSelect', options:langOptions},
                 {field:'name',header:'Name', width:280},
                 {field:'story',header:'Story', flex:1}
               ]} rows={characters} setRows={setCharacters} endpoint="/admin/characters" idField="idCharacter" />
               <UIGrid columns={[
                 {field:'idDamageBuffType',header:'ID', width:80},
-                {field:'lang',header:'Lang', width:80},
+                {field:'lang',header:'Lang', width:80, type:'singleSelect', options:langOptions},
                 {field:'name',header:'Name', flex:1}
               ]} rows={damageBuffTypes} setRows={setDamageBuffTypes} endpoint="/admin/damagebufftypes" idField="idDamageBuffType" />
               <UIGrid columns={[
                 {field:'idDamageType',header:'ID', width:80},
-                {field:'lang',header:'Lang', width:80},
+                {field:'lang',header:'Lang', width:80, type:'singleSelect', options:langOptions},
                 {field:'name',header:'Name', flex:1}
               ]} rows={damageTypes} setRows={setDamageTypes} endpoint="/admin/damagetypes" idField="idDamageType" />
             </div>
@@ -667,7 +672,7 @@ function AdminPage(){
                   {field:'bonusCritChance',header:'Crit%', width:80},
                   {field:'bonusHealth',header:'HP', width:80},
                   {field:'luminaCost',header:'Lumina', width:80},
-                  {field:'lang',header:'Lang', width:80},
+                  {field:'lang',header:'Lang', width:80, type:'singleSelect', options:langOptions},
                   {field:'name',header:'Name', width:280},
                   {field:'region',header:'Region', width:280},
                   {field:'descrptionBonusLumina',header:'Effect', width:500},
@@ -689,11 +694,11 @@ function AdminPage(){
               <UIGrid
                 columns={[
                   {field:'idWeapon',header:'ID', width:80, editable:false},
-                  {field:'character',header:'Char'},
-                  {field:'damageType',header:'Type'},
-                  {field:'damageBuffType1',header:'Buff1'},
-                  {field:'damageBuffType2',header:'Buff2'},
-                  {field:'lang',header:'Lang', width:80},
+                  {field:'character',header:'Char', width:80, type:'singleSelect', options:charOptions},
+                  {field:'damageType',header:'Type', width:80, type:'singleSelect', options:typeOptions},
+                  {field:'damageBuffType1',header:'Buff1', width:80, type:'singleSelect', options:buffOptions},
+                  {field:'damageBuffType2',header:'Buff2', width:80, type:'singleSelect', options:buffOptions},
+                  {field:'lang',header:'Lang', width:80, type:'singleSelect', options:langOptions},
                   {field:'name',header:'Name', width:280},
                   {field:'region',header:'Region', width:280},
                   {field:'unlockDescription',header:'Unlock', flex:1},

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -538,9 +538,27 @@ function AdminPage(){
   const [tab, setTab] = React.useState(0);
 
   const langOptions = ['fr','en'];
-  const charOptions = React.useMemo(() => Array.from(new Set(characters.map(c => c.idCharacter))), [characters]);
-  const typeOptions = React.useMemo(() => Array.from(new Set(damageTypes.map(t => t.idDamageType))), [damageTypes]);
-  const buffOptions = React.useMemo(() => Array.from(new Set(damageBuffTypes.map(b => b.idDamageBuffType))), [damageBuffTypes]);
+  const charOptions = React.useMemo(() => {
+    const map = new Map();
+    characters.forEach(c => {
+      if(!map.has(c.idCharacter)) map.set(c.idCharacter, c.name || c.idCharacter);
+    });
+    return Array.from(map.entries()).map(([value, label]) => ({ value, label }));
+  }, [characters]);
+  const typeOptions = React.useMemo(() => {
+    const map = new Map();
+    damageTypes.forEach(t => {
+      if(!map.has(t.idDamageType)) map.set(t.idDamageType, t.name || t.idDamageType);
+    });
+    return Array.from(map.entries()).map(([value, label]) => ({ value, label }));
+  }, [damageTypes]);
+  const buffOptions = React.useMemo(() => {
+    const map = new Map();
+    damageBuffTypes.forEach(b => {
+      if(!map.has(b.idDamageBuffType)) map.set(b.idDamageBuffType, b.name || b.idDamageBuffType);
+    });
+    return Array.from(map.entries()).map(([value, label]) => ({ value, label }));
+  }, [damageBuffTypes]);
 
 
   const loadData = () => {

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -635,20 +635,20 @@ function AdminPage(){
           {tab===0 && (
             <div className="admin-row base-row">
               <UIGrid columns={[
-                {field:'idCharacter',header:'ID'},
-                {field:'lang',header:'Lang'},
-                {field:'name',header:'Name'},
-                {field:'story',header:'Story', width:150}
+                {field:'idCharacter',header:'ID', width:80, editable:false},
+                {field:'lang',header:'Lang', width:80},
+                {field:'name',header:'Name', width:280},
+                {field:'story',header:'Story', flex:1}
               ]} rows={characters} setRows={setCharacters} endpoint="/admin/characters" idField="idCharacter" />
               <UIGrid columns={[
-                {field:'idDamageBuffType',header:'ID'},
-                {field:'lang',header:'Lang'},
-                {field:'name',header:'Name'}
+                {field:'idDamageBuffType',header:'ID', width:80},
+                {field:'lang',header:'Lang', width:80},
+                {field:'name',header:'Name', flex:1}
               ]} rows={damageBuffTypes} setRows={setDamageBuffTypes} endpoint="/admin/damagebufftypes" idField="idDamageBuffType" />
               <UIGrid columns={[
-                {field:'idDamageType',header:'ID'},
-                {field:'lang',header:'Lang'},
-                {field:'name',header:'Name'}
+                {field:'idDamageType',header:'ID', width:80},
+                {field:'lang',header:'Lang', width:80},
+                {field:'name',header:'Name', flex:1}
               ]} rows={damageTypes} setRows={setDamageTypes} endpoint="/admin/damagetypes" idField="idDamageType" />
             </div>
           )}
@@ -660,18 +660,18 @@ function AdminPage(){
             <div className="admin-row">
               <UIGrid
                 columns={[
-                  {field:'idPicto',header:'ID'},
-                  {field:'level',header:'Level'},
-                  {field:'bonusDefense',header:'Def'},
-                  {field:'bonusSpeed',header:'Speed'},
-                  {field:'bonusCritChance',header:'Crit%'},
-                  {field:'bonusHealth',header:'HP'},
-                  {field:'luminaCost',header:'Lumina'},
-                  {field:'lang',header:'Lang'},
-                  {field:'name',header:'Name'},
-                  {field:'region',header:'Region'},
-                  {field:'descrptionBonusLumina',header:'Effect', width:150},
-                  {field:'unlockDescription',header:'Unlock', width:150}
+                  {field:'idPicto',header:'ID', width:80, editable:false},
+                  {field:'level',header:'Level', width:80},
+                  {field:'bonusDefense',header:'Def', width:80},
+                  {field:'bonusSpeed',header:'Speed', width:80},
+                  {field:'bonusCritChance',header:'Crit%', width:80},
+                  {field:'bonusHealth',header:'HP', width:80},
+                  {field:'luminaCost',header:'Lumina', width:80},
+                  {field:'lang',header:'Lang', width:80},
+                  {field:'name',header:'Name', width:280},
+                  {field:'region',header:'Region', width:280},
+                  {field:'descrptionBonusLumina',header:'Effect', width:500},
+                  {field:'unlockDescription',header:'Unlock', flex:1}
                 ]}
                 rows={pictos}
                 setRows={setPictos}
@@ -688,18 +688,18 @@ function AdminPage(){
             <div className="admin-row">
               <UIGrid
                 columns={[
-                  {field:'idWeapon',header:'ID'},
+                  {field:'idWeapon',header:'ID', width:80, editable:false},
                   {field:'character',header:'Char'},
                   {field:'damageType',header:'Type'},
                   {field:'damageBuffType1',header:'Buff1'},
                   {field:'damageBuffType2',header:'Buff2'},
-                  {field:'lang',header:'Lang'},
-                  {field:'name',header:'Name'},
-                  {field:'region',header:'Region'},
-                  {field:'unlockDescription',header:'Unlock', width:150},
-                  {field:'weaponEffect1',header:'Effect1', width:150},
-                  {field:'weaponEffect2',header:'Effect2', width:150},
-                  {field:'weaponEffect3',header:'Effect3', width:150}
+                  {field:'lang',header:'Lang', width:80},
+                  {field:'name',header:'Name', width:280},
+                  {field:'region',header:'Region', width:280},
+                  {field:'unlockDescription',header:'Unlock', flex:1},
+                  {field:'weaponEffect1',header:'Effect1', width:280},
+                  {field:'weaponEffect2',header:'Effect2', width:280},
+                  {field:'weaponEffect3',header:'Effect3', width:280}
                 ]}
                 rows={weapons}
                 setRows={setWeapons}

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -713,9 +713,9 @@ function AdminPage(){
                 columns={[
                   {field:'idWeapon',header:'ID', width:80, editable:false},
                   {field:'character',header:'Char', width:80, type:'singleSelect', options:charOptions},
-                  {field:'damageType',header:'Type', width:80, type:'singleSelect', options:typeOptions},
-                  {field:'damageBuffType1',header:'Buff1', width:80, type:'singleSelect', options:buffOptions},
-                  {field:'damageBuffType2',header:'Buff2', width:80, type:'singleSelect', options:buffOptions},
+                  {field:'damageType',header:'Type', width:120, type:'singleSelect', options:typeOptions},
+                  {field:'damageBuffType1',header:'Buff1', width:120, type:'singleSelect', options:buffOptions},
+                  {field:'damageBuffType2',header:'Buff2', width:120, type:'singleSelect', options:buffOptions},
                   {field:'lang',header:'Lang', width:80, type:'singleSelect', options:langOptions},
                   {field:'name',header:'Name', width:280},
                   {field:'region',header:'Region', width:280},

--- a/src/js/components.jsx
+++ b/src/js/components.jsx
@@ -82,7 +82,7 @@ function UIGrid({columns, rows, setRows, endpoint, idField}){
   }, [rows, api, endpoint, idField, setRows]);
 
   const cols = columns.map(c => {
-    const col = {field:c.field, headerName:c.header, editable:true};
+    const col = {field:c.field, headerName:c.header, editable: c.editable !== undefined ? c.editable : true};
     if(c.width !== undefined) col.width = c.width;
     if(c.flex !== undefined) col.flex = c.flex;
     if(col.width === undefined && col.flex === undefined){

--- a/src/js/components.jsx
+++ b/src/js/components.jsx
@@ -85,6 +85,8 @@ function UIGrid({columns, rows, setRows, endpoint, idField}){
     const col = {field:c.field, headerName:c.header, editable: c.editable !== undefined ? c.editable : true};
     if(c.width !== undefined) col.width = c.width;
     if(c.flex !== undefined) col.flex = c.flex;
+    if(c.type) col.type = c.type;
+    if(Array.isArray(c.options)) col.valueOptions = c.options;
     if(col.width === undefined && col.flex === undefined){
       const sample = rows.find(r => r?.[c.field] !== undefined);
       const val = sample?.[c.field];

--- a/src/js/components.jsx
+++ b/src/js/components.jsx
@@ -86,7 +86,13 @@ function UIGrid({columns, rows, setRows, endpoint, idField}){
     if(c.width !== undefined) col.width = c.width;
     if(c.flex !== undefined) col.flex = c.flex;
     if(c.type) col.type = c.type;
-    if(Array.isArray(c.options)) col.valueOptions = c.options;
+    if(Array.isArray(c.options)) {
+      col.valueOptions = c.options;
+      if(c.options.length && typeof c.options[0] === 'object'){
+        const map = new Map(c.options.map(o => [o.value, o.label]));
+        col.valueFormatter = ({ value }) => map.get(value) ?? value;
+      }
+    }
     if(col.width === undefined && col.flex === undefined){
       const sample = rows.find(r => r?.[c.field] !== undefined);
       const val = sample?.[c.field];

--- a/src/js/components.jsx
+++ b/src/js/components.jsx
@@ -81,13 +81,21 @@ function UIGrid({columns, rows, setRows, endpoint, idField}){
     });
   }, [rows, api, endpoint, idField, setRows]);
 
-  const cols = columns.map(c => ({
-    field:c.field,
-    headerName:c.header,
-    width:c.width,
-    flex:c.flex,
-    editable:true
-  }));
+  const cols = columns.map(c => {
+    const col = {field:c.field, headerName:c.header, editable:true};
+    if(c.width !== undefined) col.width = c.width;
+    if(c.flex !== undefined) col.flex = c.flex;
+    if(col.width === undefined && col.flex === undefined){
+      const sample = rows.find(r => r?.[c.field] !== undefined);
+      const val = sample?.[c.field];
+      if(c.field === 'lang' || c.field.toLowerCase().startsWith('id') || typeof val === 'number'){
+        col.width = 80;
+      }else{
+        col.flex = 1;
+      }
+    }
+    return col;
+  });
   cols.push({
     field:'__actions',
     headerName:'',
@@ -104,7 +112,7 @@ function UIGrid({columns, rows, setRows, endpoint, idField}){
   const AddRowFooter = (props) => (
     <GridFooterContainer>
       <GridPagination {...props} />
-      <button className="btn btn-sm btn-primary" onClick={addRow}>+</button>
+      <button className="btn btn-sm btn-primary add-row-btn" onClick={addRow}>+</button>
     </GridFooterContainer>
   );
 


### PR DESCRIPTION
## Summary
- keep ID/numeric columns narrow
- spread remaining admin grid width to other columns
- add spacing for the add-row button in admin grid footer

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687f8fc3aef8832cb0bbc04a5cdd8d39