### PR TITLE
Fix redundant API calls

### DIFF
--- a/src/js/dataLoader.js
+++ b/src/js/dataLoader.js
@@ -1,15 +1,28 @@
 let dataCache = null;
 let dataLang = null;
+let dataPromise = null;
 
 async function fetchSiteData(lang = currentLang) {
   if (dataCache && dataLang === lang) {
     return dataCache;
   }
-  const api = window.CONFIG?.["clairobscur-api-url"] || '';
-  const data = await apiFetch(`${api}/public/data/${lang}`).then(r => r.json());
-  dataCache = data;
+  if (dataPromise && dataLang === lang) {
+    return dataPromise;
+  }
   dataLang = lang;
-  return data;
+  const api = window.CONFIG?.["clairobscur-api-url"] || '';
+  dataPromise = apiFetch(`${api}/public/data/${lang}`)
+    .then(r => r.json())
+    .then(data => {
+      dataCache = data;
+      dataPromise = null;
+      return data;
+    })
+    .catch(err => {
+      dataPromise = null;
+      throw err;
+    });
+  return dataPromise;
 }
 
 function preloadSiteData() {


### PR DESCRIPTION
## Summary
- consolidate site data fetch logic to cache pending promise

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687fc8ce68e4832c9a742608e8b2910e