### PR TITLE
Improve team builder modals

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -419,8 +419,8 @@ body[data-page="weapons"] .card-back {
   padding: 20px;
   margin: 10px;
   border-radius: 10px;
-  width: 90%;
-  max-width: 600px;
+  width: 95%;
+  max-width: 700px;
   max-height: 80vh;
   box-sizing: border-box;
   overflow-x: hidden;
@@ -918,7 +918,7 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 }
 .modal-options.grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
   gap: 10px;
   justify-items: center;
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -408,16 +408,23 @@ body[data-page="weapons"] .card-back {
       display: flex;
       align-items: center;
       justify-content: center;
+      padding: 10px;
+      box-sizing: border-box;
+      overflow-y: auto;
+      overflow-x: hidden;
       z-index: 1000;
     }
 .modal-content {
   background: #23263a;
   padding: 20px;
+  margin: 10px;
   border-radius: 10px;
   width: 90%;
   max-width: 600px;
   max-height: 80vh;
-  overflow: hidden;
+  box-sizing: border-box;
+  overflow-x: hidden;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
 }
@@ -897,7 +904,10 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   display: flex;
   flex-wrap: wrap;
   gap: 4px 12px;
+  padding: 0 10px;
   overflow-y: auto;
+  overflow-x: hidden;
+  box-sizing: border-box;
   flex: 1 1 auto;
 }
 .modal-options.grid {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -887,6 +887,22 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   border: 1px solid #444;
   cursor: pointer;
 }
+.modal-option.hide-check input {
+  display: none;
+}
+.modal-option.hide-check span {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 4px 6px;
+  border: 1px solid #444;
+  border-radius: 4px;
+}
+.modal-option.hide-check input:checked + span {
+  background: #3d4769;
+  border-color: #b6e4ff;
+  color: #fff;
+}
 .modal-option.grid {
   flex-direction: column;
   text-align: center;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -415,6 +415,7 @@ body[data-page="weapons"] .card-back {
   padding: 20px;
   border-radius: 10px;
   width: 90%;
+  max-width: 600px;
   max-height: 80vh;
   overflow: hidden;
   display: flex;
@@ -813,11 +814,6 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   text-align: center;
   font-size: 0.9em;
 }
-.weapon-detail,
-.picto-detail {
-  font-size: 0.9em;
-  margin-bottom: 20px;
-}
 
 .buff-row-title {
   font-family: 'Cinzel', serif;
@@ -884,6 +880,16 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   border: 1px solid #444;
   cursor: pointer;
 }
+.modal-option.grid {
+  flex-direction: column;
+  text-align: center;
+}
+.modal-option.grid img {
+  width: 64px;
+  height: 64px;
+  object-fit: contain;
+  margin-bottom: 4px;
+}
 .modal-option input:checked + span {
   color: #fffff0;
 }
@@ -893,6 +899,12 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   gap: 4px 12px;
   overflow-y: auto;
   flex: 1 1 auto;
+}
+.modal-options.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+  gap: 10px;
+  justify-items: center;
 }
 
 .modal-actions {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -890,12 +890,18 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 .modal-option.grid {
   flex-direction: column;
   text-align: center;
+  width: 100%;
+  box-sizing: border-box;
 }
 .modal-option.grid img {
   width: 64px;
   height: 64px;
   object-fit: contain;
   margin-bottom: 4px;
+}
+.modal-option.grid span {
+  display: block;
+  word-break: break-word;
 }
 .modal-option input:checked + span {
   color: #fffff0;

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -529,6 +529,9 @@ function BuildPage(){
                     </div>
                   </div>
                 </div>
+                <div className="buff-chart">
+                  <RadarChart values={col.buffStats} buffs={buffs} />
+                </div>
                 <div className="buff-row-title" data-i18n="attributes">{t('attributes')}</div>
                 <div className="buff-stats-row">
                   <div className="buff-inputs">
@@ -538,9 +541,6 @@ function BuildPage(){
                         <input type="number" min="0" max="99" value={col.buffStats[i]} onChange={e=>changeBuffStat(cidx,i,e.target.value)} />
                       </label>
                     ))}
-                  </div>
-                  <div className="buff-chart">
-                    <RadarChart values={col.buffStats} buffs={buffs} />
                   </div>
                 </div>
                 <div className="stats">
@@ -595,6 +595,9 @@ function BuildPage(){
                     </div>
                     </div>
                   </div>
+                  <div className="buff-chart">
+                    <RadarChart values={col.buffStats} buffs={buffs} />
+                  </div>
                   <div className="buff-row-title" data-i18n="attributes">{t('attributes')}</div>
                   <div className="buff-stats-row">
                     <div className="buff-inputs">
@@ -604,9 +607,6 @@ function BuildPage(){
                           <input type="number" min="0" max="99" value={col.buffStats[i]} onChange={e=>changeBuffStat(idx,i,e.target.value)} />
                         </label>
                       ))}
-                    </div>
-                    <div className="buff-chart">
-                      <RadarChart values={col.buffStats} buffs={buffs} />
                     </div>
                   </div>
                   <div className="stats">

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -335,7 +335,7 @@ function BuildPage(){
 
   function SelectionModal(){
     if(!modal) return null;
-    const {options,onSelect,multi,values,search,grid}=modal;
+    const {options,onSelect,multi,values,search,grid,hideCheck}=modal;
     const [local,setLocal]=React.useState(multi?values.slice():values||'');
     const [term,setTerm]=React.useState('');
     const list=search?options.filter(o=>{
@@ -359,7 +359,7 @@ function BuildPage(){
             <>
               <div className={`modal-options${grid?' grid':''}`}>
                 {list.map(o => (
-                  <label key={o.value} className={`modal-option${grid?' grid':''}`}>
+                  <label key={o.value} className={`modal-option${grid?' grid':''}${hideCheck?' hide-check':''}`}>
                     {o.icon && <img src={o.icon} alt="" />}
                     <input
                       type="checkbox"
@@ -387,7 +387,7 @@ function BuildPage(){
               {list.map(o => (
                 <div
                   key={o.value}
-                  className={`modal-option${grid?' grid':''}`}
+                  className={`modal-option${grid?' grid':''}${hideCheck?' hide-check':''}`}
                   onClick={() => {
                     onSelect(o.value);
                     setModal(null);
@@ -417,6 +417,10 @@ function BuildPage(){
   }
   function openWeaponModal(idx){
     const char=team[idx].character;
+    if(!char){
+      ReactToastify.toast(t('select_character_first'));
+      return;
+    }
     const cid=charIds[char];
     const opts=weapons.filter(w=>w.charId===cid).map(w=>({value:w.name,label:w.name}));
     setModal({options:opts,onSelect:val=>updateTeam(idx,{weapon:val}),grid:true});
@@ -461,7 +465,8 @@ function BuildPage(){
       multi: true,
       values: baseValues,
       search: true,
-      grid: true
+      grid: true,
+      hideCheck: true
     });
   }
 

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -335,7 +335,7 @@ function BuildPage(){
 
   function SelectionModal(){
     if(!modal) return null;
-    const {options,onSelect,multi,values,search}=modal;
+    const {options,onSelect,multi,values,search,grid}=modal;
     const [local,setLocal]=React.useState(multi?values.slice():values||'');
     const [term,setTerm]=React.useState('');
     const list=search?options.filter(o=>{
@@ -357,9 +357,10 @@ function BuildPage(){
           )}
           {multi ? (
             <>
-              <div className="modal-options">
+              <div className={`modal-options${grid?' grid':''}`}>
                 {list.map(o => (
-                  <label key={o.value} className="modal-option">
+                  <label key={o.value} className={`modal-option${grid?' grid':''}`}>
+                    {o.icon && <img src={o.icon} alt="" />}
                     <input
                       type="checkbox"
                       disabled={o.disabled}
@@ -382,17 +383,18 @@ function BuildPage(){
               </div>
             </>
           ) : (
-            <div className="modal-options">
+            <div className={`modal-options${grid?' grid':''}`}>
               {list.map(o => (
                 <div
                   key={o.value}
-                  className="modal-option"
+                  className={`modal-option${grid?' grid':''}`}
                   onClick={() => {
                     onSelect(o.value);
                     setModal(null);
                   }}
                 >
-                  {o.label}
+                  {o.icon && <img src={o.icon} alt="" />}
+                  <span>{o.label}</span>
                 </div>
               ))}
             </div>
@@ -410,14 +412,14 @@ function BuildPage(){
     const hasVerso=team.some((t,i)=>t.character==='Verso' && i!==idx);
     if(hasGustave) opts=opts.filter(ch=>ch!=='Verso');
     if(hasVerso) opts=opts.filter(ch=>ch!=='Gustave');
-    opts=opts.map(ch=>({value:ch,label:ch}));
-    setModal({options:opts,onSelect:val=>updateTeam(idx,{character:val,weapon:'',mainPictos:[null,null,null],subPictos:[]})});
+    opts=opts.map(ch=>({value:ch,label:ch,icon:`resources/images/characters/${ch.toLowerCase()}_icon.png`}));
+    setModal({options:opts,onSelect:val=>updateTeam(idx,{character:val,weapon:'',mainPictos:[null,null,null],subPictos:[]}),grid:true});
   }
   function openWeaponModal(idx){
     const char=team[idx].character;
     const cid=charIds[char];
     const opts=weapons.filter(w=>w.charId===cid).map(w=>({value:w.name,label:w.name}));
-    setModal({options:opts,onSelect:val=>updateTeam(idx,{weapon:val})});
+    setModal({options:opts,onSelect:val=>updateTeam(idx,{weapon:val}),grid:true});
   }
   function openMainModal(idx,pidx){
     const existing=team[idx].mainPictos.filter((_,i)=>i!==pidx);
@@ -432,7 +434,8 @@ function BuildPage(){
     setModal({
       options: available,
       onSelect: val => changeMain(idx, pidx, val),
-      search: true
+      search: true,
+      grid: true
     });
   }
   function openSubsModal(idx){
@@ -457,7 +460,8 @@ function BuildPage(){
       onSelect: vals => changeSubs(idx, vals),
       multi: true,
       values: baseValues,
-      search: true
+      search: true,
+      grid: true
     });
   }
 
@@ -545,7 +549,6 @@ function BuildPage(){
                   <div>{t('critical-luck')}: {stats.crit}</div>
                   <div>{t('health')}: {stats.health}</div>
                 </div>
-                {w && <div className="weapon-detail">{w.weapon_effect}</div>}
                 <div className="bottom-controls">
                   <div className="mains">
                     {col.mainPictos.map((pid,pidx)=>(
@@ -612,7 +615,6 @@ function BuildPage(){
                     <div>{t('critical-luck')}: {stats.crit}</div>
                     <div>{t('health')}: {stats.health}</div>
                   </div>
-                  {w && <div className="weapon-detail">{w.weapon_effect}</div>}
                     <div className="bottom-controls">
                       <div className="mains">
                         {col.mainPictos.map((pid,pidx)=>(

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -52,6 +52,7 @@
   "build_title": "Clair Obscur - Team builder",
   "choose_character": "Choose character",
   "choose_weapon": "Choose weapon",
+  "select_character_first": "Select a character before choosing a weapon",
   "choose_picto": "Choose picto {num}",
   "choose_luminas": "Choose luminas",
   "luminas_label": "Luminas",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -42,6 +42,7 @@
   "build_title": "Clair Obscur - Création d'équipe",
   "choose_character": "Choisir le personnage",
   "choose_weapon": "Choisir son arme",
+  "select_character_first": "Veuillez choisir un personnage avant l'arme",
   "choose_picto": "Choisir picto {num}",
   "choose_luminas": "Choisir les luminas",
   "luminas_label": "Luminas",


### PR DESCRIPTION
## Summary
- shrink modal width and remove unused weapon detail style
- support grid layout and icons in `SelectionModal`
- show character icons in the character chooser
- make weapon, picto and lumina lists responsive
- hide weapon description from team builder view

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68808268b938832c82faba6aab6b3f44