### PR TITLE
Add CSV tools for admin grids

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1003,3 +1003,8 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 .admin-tabs-nav button.active{background:#21232d;}
 .admin-tab-pane{display:none;}
 .admin-tab-pane.active{display:block;}
+
+/* CSV Import/Export */
+.import-box{background:#21232d;color:#fff;padding:10px;margin-top:10px;}
+.import-box .controls{display:flex;gap:10px;margin-bottom:5px;}
+.import-box pre{margin:0;white-space:pre-wrap;word-break:break-word;font-size:0.8em;}

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -690,6 +690,79 @@ function AdminPage(){
     return Array.from(map.entries()).map(([value, label]) => ({ value, label }));
   }, [capacityTypes]);
 
+  const charCols = React.useMemo(()=>[
+    {field:'idCharacter',header:'ID', width:80},
+    {field:'lang',header:'Lang', width:80, type:'singleSelect', options:langOptions},
+    {field:'name',header:'Name', width:280},
+    {field:'story',header:'Story', flex:1}
+  ], []);
+
+  const buffCols = React.useMemo(()=>[
+    {field:'idDamageBuffType',header:'ID', width:80},
+    {field:'lang',header:'Lang', width:80, type:'singleSelect', options:langOptions},
+    {field:'name',header:'Name', flex:1}
+  ], []);
+
+  const typeCols = React.useMemo(()=>[
+    {field:'idDamageType',header:'ID', width:80},
+    {field:'lang',header:'Lang', width:80, type:'singleSelect', options:langOptions},
+    {field:'name',header:'Name', flex:1}
+  ], []);
+
+  const pictoCols = React.useMemo(()=>[
+    {field:'idPicto',header:'ID', width:80},
+    {field:'level',header:'Level', width:80},
+    {field:'bonusDefense',header:'Def', width:80},
+    {field:'bonusSpeed',header:'Speed', width:80},
+    {field:'bonusCritChance',header:'Crit%', width:80},
+    {field:'bonusHealth',header:'HP', width:80},
+    {field:'luminaCost',header:'Lumina', width:80},
+    {field:'lang',header:'Lang', width:80, type:'singleSelect', options:langOptions},
+    {field:'name',header:'Name', width:280},
+    {field:'region',header:'Region', width:280},
+    {field:'descrptionBonusLumina',header:'Effect', width:500},
+    {field:'unlockDescription',header:'Unlock', flex:1}
+  ], []);
+
+  const weaponCols = React.useMemo(()=>[
+    {field:'idWeapon',header:'ID', width:80},
+    {field:'character',header:'Char', width:80, type:'singleSelect', options:charOptions},
+    {field:'damageType',header:'Type', width:120, type:'singleSelect', options:typeOptions},
+    {field:'damageBuffType1',header:'Buff1', width:120, type:'singleSelect', options:buffOptions},
+    {field:'damageBuffType2',header:'Buff2', width:120, type:'singleSelect', options:buffOptions},
+    {field:'lang',header:'Lang', width:80, type:'singleSelect', options:langOptions},
+    {field:'name',header:'Name', width:280},
+    {field:'region',header:'Region', width:280},
+    {field:'unlockDescription',header:'Unlock', flex:1},
+    {field:'weaponEffect1',header:'Effect1', width:280},
+    {field:'weaponEffect2',header:'Effect2', width:280},
+    {field:'weaponEffect3',header:'Effect3', width:280}
+  ], [charOptions, typeOptions, buffOptions]);
+
+  const capTypeCols = React.useMemo(()=>[
+    {field:'idCapacityType',header:'ID', width:80},
+    {field:'lang',header:'Lang', width:80, type:'singleSelect', options:langOptions},
+    {field:'name',header:'Name', flex:1}
+  ], []);
+
+  const capCols = React.useMemo(()=>[
+    {field:'idCapacity',header:'ID', width:80},
+    {field:'character',header:'Char', width:80, type:'singleSelect', options:charOptions},
+    {field:'damageType',header:'Type', width:120, type:'singleSelect', options:typeOptions},
+    {field:'type',header:'CapType', width:120, type:'singleSelect', options:capTypeOptions},
+    {field:'energyCost',header:'Energy', width:80},
+    {field:'canBreak',header:'Break', width:80},
+    {field:'isMultiTarget',header:'Multi', width:80},
+    {field:'gridPositionX',header:'PosX', width:80},
+    {field:'gridPositionY',header:'PosY', width:80},
+    {field:'lang',header:'Lang', width:80, type:'singleSelect', options:langOptions},
+    {field:'name',header:'Name', width:200},
+    {field:'effectPrimary',header:'Primary', width:200},
+    {field:'effectSecondary',header:'Secondary', width:200},
+    {field:'bonusDescription',header:'Bonus', width:200},
+    {field:'additionnalDescription',header:'More', flex:1}
+  ], [charOptions, typeOptions, capTypeOptions]);
+
 
   const initRows = React.useCallback(data => {
     if(!data) return;
@@ -831,12 +904,8 @@ function AdminPage(){
           <h2 className="admin-section" data-i18n="admin_characters">Characters</h2>
           {tab===0 && (
             <div className="admin-row">
-              <UIGrid columns={[
-                {field:'idCharacter',header:'ID', width:80},
-                {field:'lang',header:'Lang', width:80, type:'singleSelect', options:langOptions},
-                {field:'name',header:'Name', width:280},
-                {field:'story',header:'Story', flex:1}
-              ]} rows={characters} setRows={setCharacters} endpoint="/admin/characters" idField="idCharacter" />
+              <UIGrid columns={charCols} rows={characters} setRows={setCharacters} endpoint="/admin/characters" idField="idCharacter" />
+              <ImportBox columns={charCols} rows={characters} setRows={setCharacters} endpoint="/admin/characters" idField="idCharacter" label="characters" />
             </div>
           )}
         </div>
@@ -845,11 +914,8 @@ function AdminPage(){
           <h2 className="admin-section" data-i18n="admin_damage_buff_types">Damage Buff Types</h2>
           {tab===1 && (
             <div className="admin-row">
-              <UIGrid columns={[
-                {field:'idDamageBuffType',header:'ID', width:80},
-                {field:'lang',header:'Lang', width:80, type:'singleSelect', options:langOptions},
-                {field:'name',header:'Name', flex:1}
-              ]} rows={damageBuffTypes} setRows={setDamageBuffTypes} endpoint="/admin/damagebufftypes" idField="idDamageBuffType" />
+              <UIGrid columns={buffCols} rows={damageBuffTypes} setRows={setDamageBuffTypes} endpoint="/admin/damagebufftypes" idField="idDamageBuffType" />
+              <ImportBox columns={buffCols} rows={damageBuffTypes} setRows={setDamageBuffTypes} endpoint="/admin/damagebufftypes" idField="idDamageBuffType" label="damagebufftypes" />
             </div>
           )}
         </div>
@@ -858,11 +924,8 @@ function AdminPage(){
           <h2 className="admin-section" data-i18n="admin_damage_types">Damage Types</h2>
           {tab===2 && (
             <div className="admin-row">
-              <UIGrid columns={[
-                {field:'idDamageType',header:'ID', width:80},
-                {field:'lang',header:'Lang', width:80, type:'singleSelect', options:langOptions},
-                {field:'name',header:'Name', flex:1}
-              ]} rows={damageTypes} setRows={setDamageTypes} endpoint="/admin/damagetypes" idField="idDamageType" />
+              <UIGrid columns={typeCols} rows={damageTypes} setRows={setDamageTypes} endpoint="/admin/damagetypes" idField="idDamageType" />
+              <ImportBox columns={typeCols} rows={damageTypes} setRows={setDamageTypes} endpoint="/admin/damagetypes" idField="idDamageType" label="damagetypes" />
             </div>
           )}
         </div>
@@ -871,26 +934,8 @@ function AdminPage(){
           <h2 className="admin-section" data-i18n="admin_pictos">Pictos</h2>
           {tab===3 && (
             <div className="admin-row">
-              <UIGrid
-                columns={[
-                  {field:'idPicto',header:'ID', width:80},
-                  {field:'level',header:'Level', width:80},
-                  {field:'bonusDefense',header:'Def', width:80},
-                  {field:'bonusSpeed',header:'Speed', width:80},
-                  {field:'bonusCritChance',header:'Crit%', width:80},
-                  {field:'bonusHealth',header:'HP', width:80},
-                  {field:'luminaCost',header:'Lumina', width:80},
-                  {field:'lang',header:'Lang', width:80, type:'singleSelect', options:langOptions},
-                  {field:'name',header:'Name', width:280},
-                  {field:'region',header:'Region', width:280},
-                  {field:'descrptionBonusLumina',header:'Effect', width:500},
-                  {field:'unlockDescription',header:'Unlock', flex:1}
-                ]}
-                rows={pictos}
-                setRows={setPictos}
-                endpoint="/admin/pictos"
-                idField="idPicto"
-              />
+              <UIGrid columns={pictoCols} rows={pictos} setRows={setPictos} endpoint="/admin/pictos" idField="idPicto" />
+              <ImportBox columns={pictoCols} rows={pictos} setRows={setPictos} endpoint="/admin/pictos" idField="idPicto" label="pictos" />
             </div>
           )}
         </div>
@@ -899,26 +944,8 @@ function AdminPage(){
           <h2 className="admin-section" data-i18n="admin_weapons">Weapons</h2>
           {tab===4 && (
             <div className="admin-row">
-              <UIGrid
-                columns={[
-                  {field:'idWeapon',header:'ID', width:80},
-                  {field:'character',header:'Char', width:80, type:'singleSelect', options:charOptions},
-                  {field:'damageType',header:'Type', width:120, type:'singleSelect', options:typeOptions},
-                  {field:'damageBuffType1',header:'Buff1', width:120, type:'singleSelect', options:buffOptions},
-                  {field:'damageBuffType2',header:'Buff2', width:120, type:'singleSelect', options:buffOptions},
-                  {field:'lang',header:'Lang', width:80, type:'singleSelect', options:langOptions},
-                  {field:'name',header:'Name', width:280},
-                  {field:'region',header:'Region', width:280},
-                  {field:'unlockDescription',header:'Unlock', flex:1},
-                  {field:'weaponEffect1',header:'Effect1', width:280},
-                  {field:'weaponEffect2',header:'Effect2', width:280},
-                  {field:'weaponEffect3',header:'Effect3', width:280}
-                ]}
-                rows={weapons}
-                setRows={setWeapons}
-                endpoint="/admin/weapons"
-                idField="idWeapon"
-              />
+              <UIGrid columns={weaponCols} rows={weapons} setRows={setWeapons} endpoint="/admin/weapons" idField="idWeapon" />
+              <ImportBox columns={weaponCols} rows={weapons} setRows={setWeapons} endpoint="/admin/weapons" idField="idWeapon" label="weapons" />
             </div>
           )}
         </div>
@@ -927,11 +954,8 @@ function AdminPage(){
           <h2 className="admin-section" data-i18n="admin_capacity_types">Capacity Types</h2>
           {tab===5 && (
             <div className="admin-row">
-              <UIGrid columns={[
-                {field:'idCapacityType',header:'ID', width:80},
-                {field:'lang',header:'Lang', width:80, type:'singleSelect', options:langOptions},
-                {field:'name',header:'Name', flex:1}
-              ]} rows={capacityTypes} setRows={setCapacityTypes} endpoint="/admin/capacitytypes" idField="idCapacityType" />
+              <UIGrid columns={capTypeCols} rows={capacityTypes} setRows={setCapacityTypes} endpoint="/admin/capacitytypes" idField="idCapacityType" />
+              <ImportBox columns={capTypeCols} rows={capacityTypes} setRows={setCapacityTypes} endpoint="/admin/capacitytypes" idField="idCapacityType" label="capacitytypes" />
             </div>
           )}
         </div>
@@ -940,29 +964,8 @@ function AdminPage(){
           <h2 className="admin-section" data-i18n="admin_capacities">Capacities</h2>
           {tab===6 && (
             <div className="admin-row">
-              <UIGrid
-                columns={[
-                  {field:'idCapacity',header:'ID', width:80},
-                  {field:'character',header:'Char', width:80, type:'singleSelect', options:charOptions},
-                  {field:'damageType',header:'Type', width:120, type:'singleSelect', options:typeOptions},
-                  {field:'type',header:'CapType', width:120, type:'singleSelect', options:capTypeOptions},
-                  {field:'energyCost',header:'Energy', width:80},
-                  {field:'canBreak',header:'Break', width:80},
-                  {field:'isMultiTarget',header:'Multi', width:80},
-                  {field:'gridPositionX',header:'PosX', width:80},
-                  {field:'gridPositionY',header:'PosY', width:80},
-                  {field:'lang',header:'Lang', width:80, type:'singleSelect', options:langOptions},
-                  {field:'name',header:'Name', width:200},
-                  {field:'effectPrimary',header:'Primary', width:200},
-                  {field:'effectSecondary',header:'Secondary', width:200},
-                  {field:'bonusDescription',header:'Bonus', width:200},
-                  {field:'additionnalDescription',header:'More', flex:1}
-                ]}
-                rows={capacities}
-                setRows={setCapacities}
-                endpoint="/admin/capacities"
-                idField="idCapacity"
-              />
+              <UIGrid columns={capCols} rows={capacities} setRows={setCapacities} endpoint="/admin/capacities" idField="idCapacity" />
+              <ImportBox columns={capCols} rows={capacities} setRows={setCapacities} endpoint="/admin/capacities" idField="idCapacity" label="capacities" />
             </div>
           )}
         </div>

--- a/src/js/components.jsx
+++ b/src/js/components.jsx
@@ -168,3 +168,87 @@ function UIGrid({columns, rows, setRows, endpoint, idField}){
     </div>
   );
 }
+
+function ImportBox({columns, rows, setRows, endpoint, idField, label}){
+  const api = window.CONFIG?.["clairobscur-api-url"] || '';
+  const fields = columns.map(c => c.field);
+  const fileRef = React.useRef();
+  const [lines, setLines] = React.useState([]);
+  const [states, setStates] = React.useState([]); // normal,error,success,fail
+
+  const exportCsv = () => {
+    const pad = n => String(n).padStart(2, '0');
+    const d = new Date();
+    const name = `${d.getFullYear()}${pad(d.getMonth()+1)}${pad(d.getDate())}_${pad(d.getHours())}${pad(d.getMinutes())}${pad(d.getSeconds())}_${label}_${currentLang}.csv`;
+    const content = rows.map(r => fields.map(f => r[f] ?? '').join(';')).join('\n');
+    const blob = new Blob([content], {type:'text/csv'});
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = name; document.body.appendChild(a); a.click();
+    a.remove(); URL.revokeObjectURL(url);
+  };
+
+  const loadFile = e => {
+    const file = e.target.files?.[0];
+    if(!file) return;
+    file.text().then(txt => {
+      const ls = txt.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+      const st = ls.map(l => (l.split(';').length === fields.length ? 'normal' : 'error'));
+      setLines(ls); setStates(st);
+    });
+  };
+
+  const importData = async () => {
+    const newStates = [...states];
+    let newRows = [...rows];
+    for(let i=0;i<lines.length;i++){
+      if(states[i]==='error') continue;
+      const parts = lines[i].split(';');
+      const obj = {};
+      fields.forEach((f,j)=>{ obj[f] = parts[j] ?? ''; });
+      const exists = rows.some(r => r[idField] == obj[idField]);
+      const method = exists ? 'PUT' : 'POST';
+      let url = `${api}${endpoint}`;
+      if(method === 'PUT') url += `/${encodeURIComponent(obj[idField])}`;
+      try{
+        const resp = await apiFetch(url,{method,headers:{'Accept':'application/json'},body:obj});
+        if(!resp.ok) throw new Error('err');
+        let data = {...obj};
+        try{ const ct=resp.headers.get('content-type')||''; if(ct.includes('application/json')){ const d=await resp.json(); if(d&&typeof d==='object') data={...data,...d}; }}catch(e){}
+        if(exists){
+          newRows=newRows.map(r=>r[idField]==obj[idField]?{...r,...data}:r);
+        }else{
+          newRows=[...newRows,data];
+        }
+        newStates[i]='success';
+      }catch(e){ newStates[i]='fail'; }
+    }
+    setRows(newRows); setStates(newStates);
+  };
+
+  const cleanData = async () => {
+    const ls=[]; const st=[]; let newRows=[...rows];
+    for(const r of rows){
+      const url=`${api}${endpoint}/${encodeURIComponent(r[idField])}`;
+      try{ const resp=await apiFetch(url,{method:'DELETE',headers:{'Accept':'application/json'}}); if(!resp.ok) throw new Error('del'); st.push('success'); }catch(e){ st.push('fail'); }
+      ls.push(String(r[idField]));
+    }
+    setRows([]); setLines(ls); setStates(st);
+  };
+
+  return (
+    <div className="import-box">
+      <div className="controls">
+        <button className="btn btn-sm btn-secondary" onClick={exportCsv}>Exporter</button>
+        <input type="file" ref={fileRef} style={{display:'none'}} accept=".csv" onChange={loadFile}/>
+        <button className="btn btn-sm btn-secondary" onClick={()=>fileRef.current.click()}>Charger</button>
+        <button className="btn btn-sm btn-primary" onClick={importData} disabled={states.includes('error')||!lines.length}>Importer</button>
+        <button className="btn btn-sm btn-danger" onClick={cleanData}>Nettoyer</button>
+      </div>
+      <div className="log">
+        {lines.map((l,i)=>(<pre key={i} className={states[i]==='error'||states[i]==='fail'?'text-danger':states[i]==='success'?'text-success':''}>{l}</pre>))}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add ImportBox component handling CSV export/import/clean
- expose column configs in admin page and wire ImportBox
- style import box for dark theme

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68819f8aee18832c972ec0ef994b12d5