### PR TITLE
Centralize save file upload/download

### DIFF
--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -74,7 +74,6 @@ function PictosPage(){
             <div className="icon-sep"></div>
           </div>
           <input className="searchbar" id="search" placeholder="Search pictos by any field..." data-i18n-placeholder="search_placeholder"/>
-          <input type="file" id="fileInput" accept="application/json" style={{display:'none'}}/>
         </div>
         <div id="cards" className="cards"></div>
         <div id="table" className="table-view" style={{display:'none'}}></div>
@@ -111,7 +110,6 @@ function WeaponsPage(){
             <div className="icon-sep"></div>
           </div>
           <input className="searchbar" id="search" placeholder="Search..." data-i18n-placeholder="search_placeholder"/>
-          <input type="file" id="fileInput" accept="application/json" style={{display:'none'}}/>
         </div>
         <div id="cards" className="cards"></div>
         <div id="table" className="table-view" style={{display:'none'}}></div>
@@ -147,7 +145,6 @@ function OutfitsPage(){
             <div className="icon-sep"></div>
           </div>
           <input className="searchbar" id="search" placeholder="Search..." data-i18n-placeholder="search_placeholder"/>
-          <input type="file" id="fileInput" accept="application/json" style={{display:'none'}}/>
         </div>
         <div id="cards" className="cards"></div>
         <div id="table" className="table-view" style={{display:'none'}}></div>

--- a/src/js/components.jsx
+++ b/src/js/components.jsx
@@ -1,10 +1,22 @@
 const {NavLink} = ReactRouterDOM;
-const {useState} = React;
+const {useState, useRef} = React;
 const { toast } = ReactToastify;
 
 const Header = () => {
   const [menuOpen, setMenuOpen] = useState(false);
+  const fileRef = useRef();
   const closeMenu = () => setMenuOpen(false);
+  const handleDownload = () => {
+    if(window.downloadSiteData) window.downloadSiteData();
+  };
+  const handleUploadClick = () => fileRef.current?.click();
+  const handleFileChange = e => {
+    const file = e.target.files?.[0];
+    if(file && window.handleSiteUpload) {
+      window.handleSiteUpload(file);
+    }
+    e.target.value = '';
+  };
   return (
     <nav className="navbar navbar-dark">
       <div className="container-fluid header-inner">
@@ -20,8 +32,9 @@ const Header = () => {
           </ul>
           <div className="header-right">
             <div className="icon-bar header-actions">
-              <button className="icon-btn" id="downloadBtn" data-i18n-title="download" title="Download"><img src="resources/images/icons/buttons/download.png" alt=""/></button>
-              <button className="icon-btn" id="uploadBtn" data-i18n-title="upload" title="Upload"><img src="resources/images/icons/buttons/upload.png" alt=""/></button>
+              <button className="icon-btn" id="downloadBtn" data-i18n-title="download" title="Download" onClick={handleDownload}><img src="resources/images/icons/buttons/download.png" alt=""/></button>
+              <button className="icon-btn" id="uploadBtn" data-i18n-title="upload" title="Upload" onClick={handleUploadClick}><img src="resources/images/icons/buttons/upload.png" alt=""/></button>
+              <input type="file" ref={fileRef} accept="application/json" style={{display:'none'}} onChange={handleFileChange}/>
             </div>
             <div className="lang-flags">
               <span className="lang-flag fi fi-fr" data-lang="fr" id="frFlag"></span>

--- a/src/js/outfits.js
+++ b/src/js/outfits.js
@@ -32,9 +32,6 @@ function initPage(){
   document.getElementById('hideMissingBtn').addEventListener('click',()=>{hideMissing=!hideMissing;if(hideMissing)hideOwned=false;applyFilters();});
   document.getElementById('selectAllBtn').addEventListener('click',()=>{filteredOutfits.forEach(w=>myOutfits.add(w.id));applyFilters();setSavedItems(storageKey,Array.from(myOutfits));});
   document.getElementById('clearAllBtn').addEventListener('click',()=>{filteredOutfits.forEach(w=>myOutfits.delete(w.id));applyFilters();setSavedItems(storageKey,Array.from(myOutfits));});
-  document.getElementById('downloadBtn').addEventListener('click',downloadJson);
-  document.getElementById('uploadBtn').addEventListener('click',()=>document.getElementById('fileInput').click());
-  document.getElementById('fileInput').addEventListener('change',e=>{if(e.target.files&&e.target.files[0])handleSiteUpload(e.target.files[0]);e.target.value='';});
   initCharacters();
   loadData();
 }
@@ -210,15 +207,7 @@ function updateIconStates(){
   document.getElementById('hideMissingBtn').classList.toggle('toggled',hideMissing);
 }
 
-function downloadJson(){
-  setSavedItems(storageKey, Array.from(myOutfits));
-  downloadSiteData();
-  updateIconStates();
-}
 
-function handleUpload(file){
-  handleSiteUpload(file);
-}
 
 function onSiteDataUpdated(){
   myOutfits = new Set(getSavedItems(storageKey));

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -193,48 +193,6 @@ function handleCardPressLeave(e) {
       });
       return {picto: best, score};
     }
-
-    function handleUpload(file) {
-      const reader = new FileReader();
-      reader.onload = e => {
-        try {
-          const arr = JSON.parse(e.target.result);
-          if (!Array.isArray(arr)) throw new Error(t('invalid_format'));
-          let added = 0;
-          arr.forEach(entry => {
-            if (typeof entry !== 'string') return;
-            let p = pictos.find(x => x.id === entry);
-            if (!p) p = pictos.find(x => x.name.toLowerCase() === entry.toLowerCase());
-            if (!p) {
-              const {picto, score} = bestMatch(entry);
-              if (picto && score >= 0.75) {
-                if (confirm(t('no_match_confirm', {entry, picto: picto.name}))) p = picto;
-              }
-            }
-            if (p) {
-              if (!myPictosSet.has(p.id)) {
-                myPictosSet.add(p.id);
-                added++;
-              }
-            }
-          });
-          ownedCount = myPictosSet.size;
-          applyFilters();
-          notify(t('pictos_added', {count: added}));
-        } catch(err) {
-          notify(t('invalid_json'));
-        }
-      };
-      reader.readAsText(file);
-    }
-
-    function downloadJson() {
-      setSavedItems(storageKey, Array.from(myPictosSet));
-      downloadSiteData();
-      updateIconStates();
-    }
-
-
     function selectAll() {
       const total = pictosFiltered.length;
       const selected = pictosFiltered.filter(p => myPictosSet.has(p.id)).length;
@@ -325,14 +283,6 @@ function handleCardPressLeave(e) {
     }
 
     function initPage() {
-      document.getElementById('downloadBtn').addEventListener('click', downloadJson);
-      document.getElementById('uploadBtn').addEventListener('click', () => document.getElementById('fileInput').click());
-      document.getElementById('fileInput').addEventListener('change', e => {
-        if (e.target.files && e.target.files[0]) {
-          handleSiteUpload(e.target.files[0]);
-          e.target.value = '';
-        }
-      });
       document.getElementById('hideOwnedBtn').addEventListener('click', () => {
         hideOwned = !hideOwned;
         if(hideOwned) hideMissing = false;

--- a/src/js/siteStorage.js
+++ b/src/js/siteStorage.js
@@ -40,6 +40,8 @@ function handleSiteUpload(file) {
   reader.onload = e => {
     try {
       const obj = JSON.parse(e.target.result);
+      localStorage.clear();
+      siteData = { pictos: [], weapons: [], outfits: [] };
       if(Array.isArray(obj)) {
         siteData.pictos = obj;
       } else if(obj && typeof obj === 'object') {
@@ -47,6 +49,7 @@ function handleSiteUpload(file) {
         if(Array.isArray(obj.weapons)) siteData.weapons = obj.weapons;
         if(Array.isArray(obj.outfits)) siteData.outfits = obj.outfits;
       }
+      saveSiteData();
       const page = document.body.dataset.page;
       if(page==='pictos' && window.pictosPage?.onSiteDataUpdated) {
         window.pictosPage.onSiteDataUpdated();

--- a/src/js/weapons.js
+++ b/src/js/weapons.js
@@ -48,9 +48,6 @@ function initPage(){
   document.getElementById('hideMissingBtn').addEventListener('click',()=>{hideMissing=!hideMissing;if(hideMissing)hideOwned=false;applyFilters();});
   document.getElementById('selectAllBtn').addEventListener('click',()=>{filteredWeapons.forEach(w=>myWeapons.add(w.id));applyFilters();setSavedItems(storageKey,Array.from(myWeapons));});
   document.getElementById('clearAllBtn').addEventListener('click',()=>{filteredWeapons.forEach(w=>myWeapons.delete(w.id));applyFilters();setSavedItems(storageKey,Array.from(myWeapons));});
-  document.getElementById('downloadBtn').addEventListener('click',downloadJson);
-  document.getElementById('uploadBtn').addEventListener('click',()=>document.getElementById('fileInput').click());
-  document.getElementById('fileInput').addEventListener('change',e=>{if(e.target.files&&e.target.files[0])handleSiteUpload(e.target.files[0]);e.target.value='';});
   initCharacters();
   loadData();
 }
@@ -247,15 +244,7 @@ function updateIconStates(){
   document.getElementById('hideMissingBtn').classList.toggle('toggled',hideMissing);
 }
 
-function downloadJson(){
-  setSavedItems(storageKey, Array.from(myWeapons));
-  downloadSiteData();
-  updateIconStates();
-}
 
-function handleUpload(file){
-  handleSiteUpload(file);
-}
 
 function onSiteDataUpdated(){
   myWeapons = new Set(getSavedItems(storageKey));


### PR DESCRIPTION
## Summary
- centralize upload & download logic in Header
- clear local storage then save on import
- drop per-page upload/download handlers and inputs

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688325a7e34c832c994cf6a3fbcb2a2a