### PR TITLE
Implement capacity hover zoom and improve radar chart

### DIFF
--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -471,6 +471,7 @@ function BuildPage(){
     const [zone,setZone]=React.useState(null); // confirmed selection
     const [hover,setHover]=React.useState(null); // preview following cursor
     const treeImg=`resources/images/capacity_tree/${character.toLowerCase()}_tree.png`;
+    const FRAME=119;
 
     function close(){ setCapModal(null); setZone(null); setHover(null); }
 
@@ -491,7 +492,7 @@ function BuildPage(){
         if(zone) return;
         setHover(pos);
       }else{
-        const cap=caps.find(c=>Math.abs(c.posX-pos.x)<60&&Math.abs(c.posY-pos.y)<60);
+        const cap=caps.find(c=>pos.x>=c.posX && pos.x<=c.posX+FRAME && pos.y>=c.posY && pos.y<=c.posY+FRAME);
         if(cap){
           setHover({sx:cap.posX*pos.scale, sy:cap.posY*pos.scale, scale:pos.scale, w:pos.w, h:pos.h});
         }else{
@@ -508,8 +509,10 @@ function BuildPage(){
         if(zone){
           const opts=caps.map(c=>({value:c.id,label:c.name}));
           setModal({options:opts,onSelect:id=>{
-            setCapacities(cs=>cs.map(c=>c.id===id?{...c,posX:pos.x,posY:pos.y}:c));
-            if(apiUrl) apiFetch(`${apiUrl}/admin/capacities/${id}`,{method:'PUT',body:{gridPositionX:pos.x,gridPositionY:pos.y}});
+            const x=pos.x-FRAME;
+            const y=pos.y-FRAME;
+            setCapacities(cs=>cs.map(c=>c.id===id?{...c,posX:x,posY:y}:c));
+            if(apiUrl) apiFetch(`${apiUrl}/admin/capacities/${id}`,{method:'PUT',body:{gridPositionX:x,gridPositionY:y}});
             setZone(null);
             setHover(null);
           }});
@@ -525,17 +528,17 @@ function BuildPage(){
     const disp=zone||hover;
     const showOutline=edit && disp;
     const showZoom=!edit && hover;
-    const size=disp?119*disp.scale:0;
+    const size=disp?FRAME*disp.scale:0;
 
     return (
       <div className="modal" onClick={close} id="capModal">
         <div className="modal-content" onClick={e=>e.stopPropagation()} style={{position:'relative'}}>
           <img src={treeImg} alt="" onClick={handleClick} onMouseMove={handleMove} onMouseLeave={handleLeave} style={{width:'100%'}} />
           {showOutline && (
-            <div style={{position:'absolute',left:disp.sx-size/2,top:disp.sy-size/2,width:size,height:size,border:'2px dashed #fff',pointerEvents:'none'}}></div>
+            <div style={{position:'absolute',left:disp.sx-size,top:disp.sy-size,width:size,height:size,border:'2px dashed #fff',pointerEvents:'none'}}></div>
           )}
           {showZoom && (
-            <div style={{position:'absolute',left:hover.sx-size/2,top:hover.sy-size/2,width:size,height:size,border:'2px solid #fff',pointerEvents:'none',background:`url(${treeImg}) no-repeat`,backgroundSize:`${hover.w}px ${hover.h}px`,backgroundPosition:`-${hover.sx-size/2}px -${hover.sy-size/2}px`}}></div>
+            <div style={{position:'absolute',left:hover.sx,top:hover.sy,width:size,height:size,border:'2px solid #fff',pointerEvents:'none',background:`url(${treeImg}) no-repeat`,backgroundSize:`${hover.w}px ${hover.h}px`,backgroundPosition:`-${hover.sx}px -${hover.sy}px`}}></div>
           )}
           {isAdmin && (
             <div style={{marginTop:'10px',textAlign:'center'}}>

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -472,6 +472,7 @@ function BuildPage(){
     const [hover,setHover]=React.useState(null); // preview following cursor
     const imgRef=React.useRef(null);
     const [scale,setScale]=React.useState(1);
+    const [offset,setOffset]=React.useState({x:0,y:0});
     const treeImg=`resources/images/capacity_tree/${character.toLowerCase()}_tree.png`;
     const FRAME=119;
 
@@ -480,6 +481,7 @@ function BuildPage(){
     const updateScale=React.useCallback(()=>{
       if(imgRef.current && imgRef.current.naturalWidth){
         setScale(imgRef.current.clientWidth/imgRef.current.naturalWidth);
+        setOffset({x:imgRef.current.offsetLeft,y:imgRef.current.offsetTop});
         if(!zone) setHover(null);
       }
     },[zone]);
@@ -546,21 +548,21 @@ function BuildPage(){
     const showZoom=!edit && hover;
     const size=FRAME*baseScale;
 
-    const outlineLeft = disp ? disp.x*baseScale : 0;
-    const outlineTop = disp ? disp.y*baseScale : 0;
+    const outlineLeft = disp ? offset.x + disp.x*baseScale : 0;
+    const outlineTop = disp ? offset.y + disp.y*baseScale : 0;
 
     return (
       <div className="modal" onClick={close} id="capModal">
         <div className="modal-content" onClick={e=>e.stopPropagation()} style={{position:'relative'}}>
           <img ref={imgRef} src={treeImg} alt="" onLoad={updateScale} onClick={handleClick} onMouseMove={handleMove} onMouseLeave={handleLeave} style={{width:'100%'}} />
           {edit && caps.map(c=>(
-            <div key={c.id} style={{position:'absolute',left:c.posX*baseScale,top:c.posY*baseScale,width:FRAME*baseScale,height:FRAME*baseScale,border:'1px solid rgba(255,255,255,0.4)',pointerEvents:'none'}}></div>
+            <div key={c.id} style={{position:'absolute',left:offset.x + c.posX*baseScale,top:offset.y + c.posY*baseScale,width:FRAME*baseScale,height:FRAME*baseScale,border:'1px solid rgba(255,255,255,0.4)',pointerEvents:'none'}}></div>
           ))}
           {showOutline && (
             <div style={{position:'absolute',left:outlineLeft,top:outlineTop,width:size,height:size,border:'2px dashed #fff',pointerEvents:'none',transform:'translate(-100%,-100%)'}}></div>
           )}
           {showZoom && (
-            <div style={{position:'absolute',left:hover.x*baseScale,top:hover.y*baseScale,width:size,height:size,border:'2px solid #fff',pointerEvents:'none',background:`url(${treeImg}) no-repeat`,backgroundSize:`${imgRef.current?.clientWidth||0}px ${imgRef.current?.clientHeight||0}px`,backgroundPosition:`-${hover.x*baseScale}px -${hover.y*baseScale}px`}}></div>
+            <div style={{position:'absolute',left:offset.x + hover.x*baseScale,top:offset.y + hover.y*baseScale,width:size,height:size,border:'2px solid #fff',pointerEvents:'none',background:`url(${treeImg}) no-repeat`,backgroundSize:`${imgRef.current?.clientWidth||0}px ${imgRef.current?.clientHeight||0}px`,backgroundPosition:`-${offset.x + hover.x*baseScale}px -${offset.y + hover.y*baseScale}px`}}></div>
           )}
           {isAdmin && (
             <div style={{marginTop:'10px',textAlign:'center'}}>

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -509,8 +509,8 @@ function BuildPage(){
         if(zone){
           const opts=caps.map(c=>({value:c.id,label:c.name}));
           setModal({options:opts,onSelect:id=>{
-            const x=pos.x-FRAME;
-            const y=pos.y-FRAME;
+            const x=zone.x-FRAME;
+            const y=zone.y-FRAME;
             setCapacities(cs=>cs.map(c=>c.id===id?{...c,posX:x,posY:y}:c));
             if(apiUrl) apiFetch(`${apiUrl}/admin/capacities/${id}`,{method:'PUT',body:{gridPositionX:x,gridPositionY:y}});
             setZone(null);

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -470,6 +470,7 @@ function BuildPage(){
     const [edit,setEdit]=React.useState(false);
     const [zone,setZone]=React.useState(null); // confirmed selection
     const [hover,setHover]=React.useState(null); // preview following cursor
+    const imgRef=React.useRef(null);
     const treeImg=`resources/images/capacity_tree/${character.toLowerCase()}_tree.png`;
     const FRAME=119;
 
@@ -529,13 +530,17 @@ function BuildPage(){
     const showOutline=edit && disp;
     const showZoom=!edit && hover;
     const size=disp?FRAME*disp.scale:0;
+    const baseScale=disp?.scale || (imgRef.current?imgRef.current.clientWidth/imgRef.current.naturalWidth:1);
 
     return (
       <div className="modal" onClick={close} id="capModal">
         <div className="modal-content" onClick={e=>e.stopPropagation()} style={{position:'relative'}}>
-          <img src={treeImg} alt="" onClick={handleClick} onMouseMove={handleMove} onMouseLeave={handleLeave} style={{width:'100%'}} />
+          <img ref={imgRef} src={treeImg} alt="" onClick={handleClick} onMouseMove={handleMove} onMouseLeave={handleLeave} style={{width:'100%'}} />
+          {edit && caps.map(c=>(
+            <div key={c.id} style={{position:'absolute',left:c.posX*baseScale,top:c.posY*baseScale,width:FRAME*baseScale,height:FRAME*baseScale,border:'1px solid rgba(255,255,255,0.4)',pointerEvents:'none'}}></div>
+          ))}
           {showOutline && (
-            <div style={{position:'absolute',left:disp.sx-size,top:disp.sy-size,width:size,height:size,border:'2px dashed #fff',pointerEvents:'none'}}></div>
+            <div style={{position:'absolute',left:disp.sx,top:disp.sy,width:size,height:size,border:'2px dashed #fff',pointerEvents:'none',transform:'translate(-100%,-100%)'}}></div>
           )}
           {showZoom && (
             <div style={{position:'absolute',left:hover.sx,top:hover.sy,width:size,height:size,border:'2px solid #fff',pointerEvents:'none',background:`url(${treeImg}) no-repeat`,backgroundSize:`${hover.w}px ${hover.h}px`,backgroundPosition:`-${hover.sx}px -${hover.sy}px`}}></div>


### PR DESCRIPTION
## Summary
- enlarge radar chart viewBox so labels fit
- keep capacity modal open on admin edit for easier multiple edits
- show a zoom overlay when hovering capacities in non-admin mode

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688434d35380832cbef84871ae0b12df