### PR TITLE
UI tweaks for team builder

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -920,12 +920,15 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   grid-template-columns: 1fr 1fr;
   gap:4px 8px;
   align-items:center;
+  justify-items:center;
 }
 .buff-label {
   text-align:right;
 }
 .buff-inputs input {
-  width:100%;
+  width:60px;
+  margin-left:auto;
+  margin-right:auto;
   background:#262b36;
   color:#fff;
   border:1px solid #555;
@@ -1144,5 +1147,5 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 }
 .cap-tooltip-title{color:#b6e4ff;font-weight:bold;margin-bottom:4px;}
 .tip-hover{position:relative;cursor:pointer;}
-.tip-hover .tooltip-text{display:none;position:absolute;background:rgba(0,0,0,0.8);color:#fff;padding:4px 6px;border-radius:4px;top:-6px;left:50%;transform:translate(-50%,-100%);white-space:pre-line;z-index:1000;}
+.tip-hover .tooltip-text{display:none;position:absolute;background:rgba(0,0,0,0.8);color:#fff;padding:4px 8px;border-radius:4px;top:-6px;left:50%;transform:translate(-50%,-100%);white-space:pre-line;z-index:1000;max-width:240px;min-width:160px;}
 .tip-hover:hover .tooltip-text{display:block;}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -865,6 +865,7 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   cursor: pointer;
   text-align: center;
   transition: transform 0.2s;
+  font-size: 1.1em;
 }
 .weapon-name:hover {
   transform: scale(1.1);
@@ -896,37 +897,35 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 .lumina-total {
   display: block;
   width: 100%;
-  margin-top: 2px;
+  margin-top: 6px;
   color: #CDB48E;
   text-align: center;
-  font-size: 0.9em;
+  font-size: 1.1em;
 }
 
 .buff-row-title {
   font-family: 'Cinzel', serif;
   color: #e0e0ff;
   margin-bottom: 4px;
+  text-align: center;
 }
 .buff-stats-row {
   display:flex;
   gap:10px;
-  margin-bottom:10px;
+  margin-bottom:14px;
 }
 .buff-inputs {
   flex:1;
-  display:flex;
-  flex-direction:column;
-  gap:4px;
-}
-.buff-inputs label {
-  display:flex;
-  justify-content:center;
+  display:grid;
+  grid-template-columns: 1fr 60px;
+  gap:4px 8px;
   align-items:center;
-  gap:4px;
+}
+.buff-label {
+  text-align:right;
 }
 .buff-inputs input {
   width:60px;
-  margin-left:4px;
   background:#262b36;
   color:#fff;
   border:1px solid #555;
@@ -965,14 +964,28 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   cursor: pointer;
   text-align: center;
   margin: 6px 0;
+  font-size: 1.1em;
   transition: transform 0.2s;
   display: block;
 }
 .config-cap-link:hover {
   transform: scale(1.1);
 }
+.capacity-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: 6px;
+  text-align: center;
+}
+.capacity-name {
+  font-size: 0.9em;
+}
 .bottom-controls {
   margin-top: auto;
+}
+.mains {
+  margin-bottom: 8px;
 }
 .modal-option {
   display: inline-flex;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -917,7 +917,7 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 .buff-inputs {
   flex:1;
   display:grid;
-  grid-template-columns: 1fr 60px;
+  grid-template-columns: 1fr 1fr;
   gap:4px 8px;
   align-items:center;
 }
@@ -925,7 +925,7 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   text-align:right;
 }
 .buff-inputs input {
-  width:60px;
+  width:100%;
   background:#262b36;
   color:#fff;
   border:1px solid #555;
@@ -1143,3 +1143,6 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   z-index:1100;
 }
 .cap-tooltip-title{color:#b6e4ff;font-weight:bold;margin-bottom:4px;}
+.tip-hover{position:relative;cursor:pointer;}
+.tip-hover .tooltip-text{display:none;position:absolute;background:rgba(0,0,0,0.8);color:#fff;padding:4px 6px;border-radius:4px;top:-6px;left:50%;transform:translate(-50%,-100%);white-space:pre-line;z-index:1000;}
+.tip-hover:hover .tooltip-text{display:block;}

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -170,11 +170,12 @@ function RadarChart({values,buffs}){
   return (
     <svg viewBox="-10 -10 120 120" className="radar-chart">
       <polygon points={pts} fill="rgba(0,128,255,0.4)" stroke="#0af" />
-      {values.map((v,i)=>{ 
-        const a = -Math.PI/2 + i*angleStep; 
-        const x = center + Math.cos(a)*(radius+6); 
-        const y = center + Math.sin(a)*(radius+6); 
-        const grade = buffs[0]===(i+1)?'S':buffs[1]===(i+1)?'A':''; 
+      {values.map((v,i)=>{
+        const a = -Math.PI/2 + i*angleStep;
+        const x = center + Math.cos(a)*(radius+6);
+        const y = center + Math.sin(a)*(radius+6);
+        const map={vitality:1,strength:2,agility:3,defense:4,luck:5};
+        const grade = map[buffs[0]]===(i+1)?'S':map[buffs[1]]===(i+1)?'A':'';
         const label = t('damage_buff_type_'+(i+1));
         return (
           <text key={i} x={x} y={y} fontSize="6" fill="#fff" textAnchor="middle" dominantBaseline="middle">
@@ -235,7 +236,6 @@ function BuildPage(){
   }
 
   function mapWeapons(list){
-    const buffMap={vitality:1,strength:2,agility:3,defense:4,luck:5};
     return list.map(w=>{
       const effect=[w.weaponEffect1,w.weaponEffect2,w.weaponEffect3]
         .filter(Boolean).join(' ');
@@ -248,9 +248,7 @@ function BuildPage(){
         unlock_description:w.unlockDescription||null,
         damage_type:w.damageType||'',
         weapon_effect:effect,
-        damage_buff:[w.damageBuffType1,w.damageBuffType2]
-          .filter(Boolean)
-          .map(b=>buffMap[b]||parseInt(b)||0)
+        damage_buff:[w.damageBuffType1,w.damageBuffType2].filter(Boolean)
       };
     });
   }
@@ -577,7 +575,16 @@ function BuildPage(){
               onMouseEnter={()=>setHover({x:c.posX,y:c.posY,cap:c})}
               onMouseLeave={()=>setHover(null)}
               onClick={()=>toggleCapacity(index,c.id)}
-              style={{position:'absolute',left:offset.x + c.posX*baseScale,top:offset.y + c.posY*baseScale,width:FRAME*baseScale,height:FRAME*baseScale,opacity:0,pointerEvents:'auto',border:team[index]?.capacities.includes(c.id)?'2px solid #0af':'none'}}
+              style={{
+                position:'absolute',
+                left:offset.x + c.posX*baseScale,
+                top:offset.y + c.posY*baseScale,
+                width:FRAME*baseScale,
+                height:FRAME*baseScale,
+                pointerEvents:'auto',
+                borderRadius:'50%',
+                boxShadow:team[index]?.capacities.includes(c.id)?'0 0 10px 3px #0f0':'none'
+              }}
             ></div>
           ))}
           {edit && caps.map(c=>(
@@ -804,9 +811,9 @@ function BuildPage(){
                     {col.mainPictos.map((pid,pidx)=>(
                       <div key={pidx}>
                         {pid
-                          ? (()=>{const desc=pictos.find(pc=>pc.id===pid)?.unlock_description||'';return (
+                          ? (()=>{const pic=pictos.find(pc=>pc.id===pid);const desc=pic?.unlock_description||pic?.bonus_lumina||'';return (
                               <span className="picto-name tip-hover" onClick={()=>openMainModal(cidx,pidx)}>
-                                {pictos.find(pc=>pc.id===pid)?.name}
+                                {pic?.name}
                                 {desc && <span className="tooltip-text">{desc}</span>}
                               </span>
                             );})()
@@ -885,9 +892,9 @@ function BuildPage(){
                         {col.mainPictos.map((pid,pidx)=>(
                           <div key={pidx}>
                             {pid
-                              ? (()=>{const desc=pictos.find(pc=>pc.id===pid)?.unlock_description||'';return (
+                              ? (()=>{const pic=pictos.find(pc=>pc.id===pid);const desc=pic?.unlock_description||pic?.bonus_lumina||'';return (
                                   <span className="picto-name tip-hover" onClick={()=>openMainModal(idx,pidx)}>
-                                    {pictos.find(pc=>pc.id===pid)?.name}
+                                    {pic?.name}
                                     {desc && <span className="tooltip-text">{desc}</span>}
                                   </span>
                                 );})()

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -178,8 +178,8 @@ function RadarChart({values,buffs}){
         const label = t('damage_buff_type_'+(i+1));
         return (
           <text key={i} x={x} y={y} fontSize="6" fill="#fff" textAnchor="middle" dominantBaseline="middle">
-            <tspan x={x} dy="-4">{label}</tspan>
-            <tspan x={x} dy="6">{v}{grade?` ${grade}`:''}</tspan>
+            <tspan x={x} dy="-4">{label}{grade?` ${grade}`:''}</tspan>
+            <tspan x={x} dy="6">{v}</tspan>
           </text>
         );
       })}
@@ -740,7 +740,7 @@ function BuildPage(){
                     : <div className="char-add" onClick={()=>openCharModal(cidx)}>+</div>}
                   <div className="weapon-box">
                     {col.weapon
-                      ? <span className="weapon-name" onClick={()=>openWeaponModal(cidx)}>{col.weapon}</span>
+                      ? <span className="weapon-name" title={w?.weapon_effect||''} onClick={()=>openWeaponModal(cidx)}>{col.weapon}</span>
                       : <div className="weapon-add" onClick={()=>openWeaponModal(cidx)}>Arme</div>}
                   <div className="weapon-buff">
                       {w ? (buffs.length>0 ? `${buffs.map(b=>t(b)).join(', ')}` : '') : t('no_weapon')}
@@ -748,7 +748,14 @@ function BuildPage(){
                   </div>
                 </div>
                 {col.character && (
-                  <div className="config-cap-link" onClick={()=>openCapacityModal(cidx)} data-i18n="config_capacities">{t('config_capacities')}</div>
+                  <>
+                    <div className="config-cap-link" onClick={()=>openCapacityModal(cidx)} data-i18n="config_capacities">{t('config_capacities')}</div>
+                    <div className="capacity-list">
+                      {capacities.filter(c=>c.character===charIds[col.character]).slice(0,6).map(cap=>(
+                        <div key={cap.id} className="capacity-name">{cap.name}</div>
+                      ))}
+                    </div>
+                  </>
                 )}
                 <div className="buff-chart">
                   <RadarChart values={col.buffStats} buffs={buffs} />
@@ -757,25 +764,19 @@ function BuildPage(){
                 <div className="buff-stats-row">
                   <div className="buff-inputs">
                     {[1,2,3,4,5].map((id,i)=>(
-                      <label key={id}>
-                        {t('damage_buff_type_'+id)}:
-                        <input type="number" min="0" max="99" value={col.buffStats[i]} onChange={e=>changeBuffStat(cidx,i,e.target.value)} />
-                      </label>
+                      <React.Fragment key={id}>
+                        <label className="buff-label" htmlFor={`b${cidx}-${id}`}>{t('damage_buff_type_'+id)}</label>
+                        <input id={`b${cidx}-${id}`} type="number" min="0" max="99" value={col.buffStats[i]} onChange={e=>changeBuffStat(cidx,i,e.target.value)} />
+                      </React.Fragment>
                     ))}
                   </div>
-                </div>
-                <div className="stats">
-                  <div>{t('defense')}: {stats.def}</div>
-                  <div>{t('speed')}: {stats.speed}</div>
-                  <div>{t('critical-luck')}: {stats.crit}</div>
-                  <div>{t('health')}: {stats.health}</div>
                 </div>
                 <div className="bottom-controls">
                   <div className="mains">
                     {col.mainPictos.map((pid,pidx)=>(
                       <div key={pidx}>
                         {pid
-                          ? <span className="picto-name" onClick={()=>openMainModal(cidx,pidx)}>{pictos.find(pc=>pc.id===pid)?.name}</span>
+                          ? <span className="picto-name" title={pictos.find(pc=>pc.id===pid)?.unlock_description||''} onClick={()=>openMainModal(cidx,pidx)}>{pictos.find(pc=>pc.id===pid)?.name}</span>
                           : <div className="picto-add" onClick={()=>openMainModal(cidx,pidx)}>Picto</div>}
                       </div>
                     ))}
@@ -809,7 +810,7 @@ function BuildPage(){
                       : <div className="char-add" onClick={()=>openCharModal(idx)}>+</div>}
                     <div className="weapon-box">
                     {col.weapon
-                      ? <span className="weapon-name" onClick={()=>openWeaponModal(idx)}>{col.weapon}</span>
+                      ? <span className="weapon-name" title={w?.weapon_effect||''} onClick={()=>openWeaponModal(idx)}>{col.weapon}</span>
                       : <div className="weapon-add" onClick={()=>openWeaponModal(idx)}>Arme</div>}
                     <div className="weapon-buff">
                       {w ? (buffs.length>0 ? `${buffs.map(b=>t(b)).join(', ')}` : '') : t('no_weapon')}
@@ -817,7 +818,14 @@ function BuildPage(){
                     </div>
                   </div>
                   {col.character && (
-                    <div className="config-cap-link" onClick={()=>openCapacityModal(idx)} data-i18n="config_capacities">{t('config_capacities')}</div>
+                    <>
+                      <div className="config-cap-link" onClick={()=>openCapacityModal(idx)} data-i18n="config_capacities">{t('config_capacities')}</div>
+                      <div className="capacity-list">
+                        {capacities.filter(c=>c.character===charIds[col.character]).slice(0,6).map(cap=>(
+                          <div key={cap.id} className="capacity-name">{cap.name}</div>
+                        ))}
+                      </div>
+                    </>
                   )}
                   <div className="buff-chart">
                     <RadarChart values={col.buffStats} buffs={buffs} />
@@ -826,25 +834,19 @@ function BuildPage(){
                   <div className="buff-stats-row">
                     <div className="buff-inputs">
                       {[1,2,3,4,5].map((id,i)=>(
-                        <label key={id}>
-                          {t('damage_buff_type_'+id)}:
-                          <input type="number" min="0" max="99" value={col.buffStats[i]} onChange={e=>changeBuffStat(idx,i,e.target.value)} />
-                        </label>
+                        <React.Fragment key={id}>
+                          <label className="buff-label" htmlFor={`b${idx}-${id}`}>{t('damage_buff_type_'+id)}</label>
+                          <input id={`b${idx}-${id}`} type="number" min="0" max="99" value={col.buffStats[i]} onChange={e=>changeBuffStat(idx,i,e.target.value)} />
+                        </React.Fragment>
                       ))}
                     </div>
-                  </div>
-                  <div className="stats">
-                    <div>{t('defense')}: {stats.def}</div>
-                    <div>{t('speed')}: {stats.speed}</div>
-                    <div>{t('critical-luck')}: {stats.crit}</div>
-                    <div>{t('health')}: {stats.health}</div>
                   </div>
                     <div className="bottom-controls">
                       <div className="mains">
                         {col.mainPictos.map((pid,pidx)=>(
                           <div key={pidx}>
                             {pid
-                              ? <span className="picto-name" onClick={()=>openMainModal(idx,pidx)}>{pictos.find(pc=>pc.id===pid)?.name}</span>
+                              ? <span className="picto-name" title={pictos.find(pc=>pc.id===pid)?.unlock_description||''} onClick={()=>openMainModal(idx,pidx)}>{pictos.find(pc=>pc.id===pid)?.name}</span>
                               : <div className="picto-add" onClick={()=>openMainModal(idx,pidx)}>Picto</div>}
                           </div>
                         ))}


### PR DESCRIPTION
## Summary
- adjust radar chart labels to show S/A grades
- add capacity list display on team builder
- enlarge fonts and spacing in team builder styles
- show weapon and picto descriptions as tooltips

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688475038f38832c97447cd39e96337c