### PR TITLE
Fix character-specific weapon storage

### DIFF
--- a/src/js/siteStorage.js
+++ b/src/js/siteStorage.js
@@ -1,20 +1,36 @@
-let siteData = { pictos: [], weapons: [], outfits: [] };
+let siteData = { pictos: [], weapons: {}, outfits: [] };
 
 function loadSiteData() {
   const saved = localStorage.getItem('siteData');
   if(saved) {
     try { siteData = JSON.parse(saved); }
-    catch(e) { siteData = { pictos: [], weapons: [], outfits: [] }; }
+    catch(e) { siteData = { pictos: [], weapons: {}, outfits: [] }; }
   }
 }
 
-function getSavedItems(key) {
+function getSavedItems(key, charId) {
+  if(key === 'weapons' && charId !== undefined) {
+    const data = siteData.weapons;
+    if(Array.isArray(data)) return data;
+    const arr = data?.[charId];
+    return Array.isArray(arr) ? arr : [];
+  }
   const arr = siteData[key];
   return Array.isArray(arr) ? arr : [];
 }
 
-function setSavedItems(key, arr) {
-  siteData[key] = Array.from(new Set(arr));
+function setSavedItems(key, arr, charId) {
+  if(key === 'weapons' && charId !== undefined) {
+    if(Array.isArray(siteData.weapons)) {
+      siteData.weapons = { [charId]: siteData.weapons };
+    }
+    if(typeof siteData.weapons !== 'object' || siteData.weapons === null) {
+      siteData.weapons = {};
+    }
+    siteData.weapons[charId] = Array.from(new Set(arr));
+  } else {
+    siteData[key] = Array.from(new Set(arr));
+  }
   saveSiteData();
 }
 
@@ -41,12 +57,12 @@ function handleSiteUpload(file) {
     try {
       const obj = JSON.parse(e.target.result);
       localStorage.clear();
-      siteData = { pictos: [], weapons: [], outfits: [] };
+      siteData = { pictos: [], weapons: {}, outfits: [] };
       if(Array.isArray(obj)) {
         siteData.pictos = obj;
       } else if(obj && typeof obj === 'object') {
         if(Array.isArray(obj.pictos)) siteData.pictos = obj.pictos;
-        if(Array.isArray(obj.weapons)) siteData.weapons = obj.weapons;
+        if(Array.isArray(obj.weapons) || typeof obj.weapons === 'object') siteData.weapons = obj.weapons;
         if(Array.isArray(obj.outfits)) siteData.outfits = obj.outfits;
       }
       saveSiteData();

--- a/src/js/weapons.js
+++ b/src/js/weapons.js
@@ -46,8 +46,8 @@ function initPage(){
   document.getElementById('search').addEventListener('input', applyFilters);
   document.getElementById('hideOwnedBtn').addEventListener('click',()=>{hideOwned=!hideOwned;if(hideOwned)hideMissing=false;applyFilters();});
   document.getElementById('hideMissingBtn').addEventListener('click',()=>{hideMissing=!hideMissing;if(hideMissing)hideOwned=false;applyFilters();});
-  document.getElementById('selectAllBtn').addEventListener('click',()=>{filteredWeapons.forEach(w=>myWeapons.add(w.id));applyFilters();setSavedItems(storageKey,Array.from(myWeapons));});
-  document.getElementById('clearAllBtn').addEventListener('click',()=>{filteredWeapons.forEach(w=>myWeapons.delete(w.id));applyFilters();setSavedItems(storageKey,Array.from(myWeapons));});
+  document.getElementById('selectAllBtn').addEventListener('click',()=>{filteredWeapons.forEach(w=>myWeapons.add(w.id));applyFilters();setSavedItems(storageKey,Array.from(myWeapons),currentCharId);});
+  document.getElementById('clearAllBtn').addEventListener('click',()=>{filteredWeapons.forEach(w=>myWeapons.delete(w.id));applyFilters();setSavedItems(storageKey,Array.from(myWeapons),currentCharId);});
   initCharacters();
   loadData();
 }
@@ -64,6 +64,7 @@ function initCharacters(){
     img.addEventListener('click',()=>{
       currentCharacter=c;
       currentCharId=characterIds[c];
+      myWeapons = new Set(getSavedItems(storageKey, currentCharId));
       document.querySelectorAll('.char-icon').forEach(i=>i.classList.toggle('active',i.dataset.char===c));
       applyFilters();
     });
@@ -119,7 +120,7 @@ function loadData(){
     initCharacters();
     const list = mapWeapons(data.weapons || []);
     allWeapons=list.map(w=>({id:w.id,...w}));
-    getSavedItems(storageKey).forEach(id=>myWeapons.add(id));
+    myWeapons = new Set(getSavedItems(storageKey, currentCharId));
     applyFilters();
   });
 }
@@ -177,7 +178,7 @@ function toggleWeapon(id){
     updateIconStates();
   }
 
-  setSavedItems(storageKey, Array.from(myWeapons));
+  setSavedItems(storageKey, Array.from(myWeapons), currentCharId);
 }
 
 function render(){
@@ -243,7 +244,7 @@ function updateIconStates(){
 
 
 function onSiteDataUpdated(){
-  myWeapons = new Set(getSavedItems(storageKey));
+  myWeapons = new Set(getSavedItems(storageKey, currentCharId));
   applyFilters();
 }
 


### PR DESCRIPTION
## Summary
- handle weapon collections per character in localStorage
- update weapons page to load/save inventory per selected character

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68848dd7121c832cad6bad654ccaf0ed