### PR TITLE
Fix HTML tags in game translations

### DIFF
--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -778,7 +778,12 @@ function BuildPage(){
                       ? (()=>{const desc=(w?.weapon_effect_lines||[]).join('\n');return (
                           <span className="weapon-name tip-hover" onClick={()=>openWeaponModal(cidx)}>
                             {col.weapon}
-                            {desc && <span className="tooltip-text">{desc}</span>}
+                            {desc && (
+                              <span
+                                className="tooltip-text"
+                                dangerouslySetInnerHTML={{__html: window.formatGameString(desc)}}
+                              />
+                            )}
                           </span>
                         );})()
                       : <div className="weapon-add" onClick={()=>openWeaponModal(cidx)}>Arme</div>}
@@ -820,7 +825,12 @@ function BuildPage(){
                           ? (()=>{const pic=pictos.find(pc=>pc.id===pid);const desc=pic?.bonus_lumina||'';return (
                               <span className="picto-name tip-hover" onClick={()=>openMainModal(cidx,pidx)}>
                                 {pic?.name}
-                                {desc && <span className="tooltip-text">{desc}</span>}
+                                {desc && (
+                                  <span
+                                    className="tooltip-text"
+                                    dangerouslySetInnerHTML={{__html: window.formatGameString(desc)}}
+                                  />
+                                )}
                               </span>
                             );})()
                           : <div className="picto-add" onClick={()=>openMainModal(cidx,pidx)}>Picto</div>}
@@ -859,7 +869,12 @@ function BuildPage(){
                       ? (()=>{const desc=(w?.weapon_effect_lines||[]).join('\n');return (
                           <span className="weapon-name tip-hover" onClick={()=>openWeaponModal(idx)}>
                             {col.weapon}
-                            {desc && <span className="tooltip-text">{desc}</span>}
+                            {desc && (
+                              <span
+                                className="tooltip-text"
+                                dangerouslySetInnerHTML={{__html: window.formatGameString(desc)}}
+                              />
+                            )}
                           </span>
                         );})()
                       : <div className="weapon-add" onClick={()=>openWeaponModal(idx)}>Arme</div>}
@@ -901,7 +916,12 @@ function BuildPage(){
                               ? (()=>{const pic=pictos.find(pc=>pc.id===pid);const desc=pic?.bonus_lumina||'';return (
                                   <span className="picto-name tip-hover" onClick={()=>openMainModal(idx,pidx)}>
                                     {pic?.name}
-                                    {desc && <span className="tooltip-text">{desc}</span>}
+                                    {desc && (
+                                      <span
+                                        className="tooltip-text"
+                                        dangerouslySetInnerHTML={{__html: window.formatGameString(desc)}}
+                                      />
+                                    )}
                                   </span>
                                 );})()
                               : <div className="picto-add" onClick={()=>openMainModal(idx,pidx)}>Picto</div>}

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -628,7 +628,9 @@ function BuildPage(){
                 style={{ left: leftPos, top: topPos }}
               >
                 <div className="cap-tooltip-title">{hover.cap.name}</div>
-                <div>{hover.cap.desc}</div>
+                <div
+                  dangerouslySetInnerHTML={{ __html: hover.cap.desc }}
+                />
               </div>
             );
           })()}

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -30,7 +30,7 @@ function tg(key, label, vars){
       str = str.replace(`{${k}}`, vars[k]);
     }
   }
-  return showLabels ? key : str;
+  return showLabels ? key : formatGameString(str);
 }
 
 function formatGameString(str){
@@ -140,3 +140,4 @@ window.t = t;
 window.tg = tg;
 window.setShowLabels = setShowLabels;
 window.bindShowLabelsToggle = bindShowLabelsToggle;
+window.formatGameString = formatGameString;


### PR DESCRIPTION
## Summary
- render game translations properly by returning formatted HTML in `tg`
- export `formatGameString` for use in React components
- display translated text with icons via `dangerouslySetInnerHTML`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68866008c124832cad7c70b8325930b2