### PR TITLE
Fix contributor edit popup crash

### DIFF
--- a/src/js/outfits.js
+++ b/src/js/outfits.js
@@ -5,6 +5,7 @@ let characterIds = Object.fromEntries(defaultCharacters.map((c,i)=>[c,i+1]));
 const defaultCharKeys=defaultCharacters.map(c=>c.toLowerCase());
 let charKeysById=Object.fromEntries(defaultCharKeys.map((k,i)=>[i+1,k]));
 let allOutfits = [];
+window.allOutfits = allOutfits;
 let outfits = [];
 let filteredOutfits = [];
 let myOutfits = new Set();
@@ -101,6 +102,7 @@ function loadData(){
     initCharacters();
     const list = mapOutfits(data.outfits || []);
     allOutfits=list.map(w=>({id:w.id,...w}));
+    window.allOutfits = allOutfits;
     getSavedItems(storageKey).forEach(id=>myOutfits.add(id));
     applyFilters();
   });
@@ -241,4 +243,5 @@ function onSiteDataUpdated(){
 }
 
 window.outfitsPage = { initPage, updateTranslations, loadData, render, onSiteDataUpdated, sortTableCol };
+window.allOutfits = allOutfits;
 })();

--- a/src/js/weapons.js
+++ b/src/js/weapons.js
@@ -33,6 +33,7 @@ const damageIcons={
   'none':'physical'
 };
 let allWeapons = [];
+window.allWeapons = allWeapons;
 let weapons = [];
 let filteredWeapons = [];
 let damageBuffNames = {};
@@ -150,6 +151,7 @@ function loadData(){
     initCharacters();
     const list = mapWeapons(data.weapons || []);
     allWeapons=list.map(w=>({id:w.id,...w}));
+    window.allWeapons = allWeapons;
     myWeapons = new Set(getSavedItems(storageKey, currentCharId));
     applyFilters();
   });
@@ -285,4 +287,5 @@ function onSiteDataUpdated(){
 }
 
 window.weaponsPage = { initPage, updateTranslations, loadData, render, onSiteDataUpdated, sortTableCol };
+window.allWeapons = allWeapons;
 })();


### PR DESCRIPTION
## Summary
- expose `allOutfits` and `allWeapons` so contributor modals can access them

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6887ce6dcd38832c96ab8396dd8a13f0