### PR TITLE
UI improvements for build modals

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -340,25 +340,9 @@ body[data-page="pictos"] .card.owned::after {
       display: flex;
       flex-direction: column;
       box-sizing: border-box;
-      padding: 22px 24px 18px 40px;
+      padding: 34px 60px 20px 60px;
     }
-body[data-page="weapons"] .card-face {
-  padding: 34px 60px 20px 60px;
-}
-body[data-page="outfits"] .card-face {
-  padding: 34px 60px 20px 60px;
-}
-body[data-page="pictos"] .card-face {
-  padding: 34px 60px 20px 60px;
-}
-body[data-page="weapons"] .card-back {
-  padding-left: 100px;
-  padding-right: 50px;
-}
-body[data-page="outfits"] .card-back {
-  padding-left: 100px;
-  padding-right: 50px;
-}
+
 .card-front {
   transform: rotateY(0deg);
 }
@@ -754,7 +738,7 @@ body {
   opacity: 0.8;
 }
 
-.char-select{display:flex;gap:12px;flex-wrap:wrap;justify-content:center;margin-bottom:20px;}
+.char-select{display:flex;gap:20px;flex-wrap:wrap;justify-content:center;margin-bottom:20px;}
 .char-select img{width:128px;height:128px;opacity:0.4;cursor:pointer;transition:opacity .2s;}
 .char-select img:hover{opacity:0.6;}
 .char-select img.active{opacity:1;}
@@ -1215,4 +1199,13 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   display:block;
   width:100%;
   margin-bottom:6px;
+}
+.build-table tbody tr{
+  cursor:pointer;
+}
+.build-table td.desc-cell{
+  max-width:300px;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
 }

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -109,7 +109,7 @@ function WeaponsPage(){
             <button className="icon-btn" id="tableViewBtn" data-i18n-title="table_view" title="Table view"><img src="resources/images/icons/buttons/tab_view.png" alt=""/></button>
             <div className="icon-sep"></div>
           </div>
-          <input className="searchbar" id="search" placeholder="Search..." data-i18n-placeholder="search_placeholder"/>
+          <input className="searchbar" id="search" placeholder="Search..." data-i18n-placeholder="search_weapons_placeholder"/>
         </div>
         <div id="cards" className="cards"></div>
         <div id="table" className="table-view" style={{display:'none'}}></div>
@@ -144,7 +144,7 @@ function OutfitsPage(){
             <button className="icon-btn" id="tableViewBtn" data-i18n-title="table_view" title="Table view"><img src="resources/images/icons/buttons/tab_view.png" alt=""/></button>
             <div className="icon-sep"></div>
           </div>
-          <input className="searchbar" id="search" placeholder="Search..." data-i18n-placeholder="search_placeholder"/>
+          <input className="searchbar" id="search" placeholder="Search..." data-i18n-placeholder="search_outfits_placeholder"/>
         </div>
         <div id="cards" className="cards"></div>
         <div id="table" className="table-view" style={{display:'none'}}></div>
@@ -532,6 +532,7 @@ function BuildPage(){
     return (
       <div className="modal" onClick={()=>setShowBuildSearch(false)} id="buildSearchModal">
         <div className="modal-content" onClick={e=>e.stopPropagation()}>
+          <h2>{t('search_builds')}</h2>
           <input
             className="searchbar modal-filter"
             style={{width:'100%'}}
@@ -539,13 +540,58 @@ function BuildPage(){
             value={term}
             onChange={e=>setTerm(e.target.value)}
           />
-          <div className="modal-options">
-            {results.map(b=>(
-              <div key={b.id} className="modal-option hide-check" onClick={()=>{loadBuild(b.id); setShowBuildSearch(false);}}>
-                <span>{b.title || b.id}</span>
-              </div>
-            ))}
-          </div>
+          <table className="build-table">
+            <thead>
+              <tr>
+                <th>{t('build_title_col')}</th>
+                <th>{t('build_desc_col')}</th>
+                <th>{t('build_author_col')}</th>
+                <th>{t('build_updated_col')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {results.map(b=>(
+                <tr key={b.id} onClick={()=>{loadBuild(b.id); setShowBuildSearch(false);}}>
+                  <td>{b.title || b.id}</td>
+                  <td className="desc-cell">{b.description}</td>
+                  <td>{b.author}</td>
+                  <td>{b.updated}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  }
+
+  function BuildListModal(){
+    if(!modal || !modal.buildList) return null;
+    const {builds,onSelect}=modal;
+    return (
+      <div className="modal" onClick={()=>setModal(null)} id="buildListModal">
+        <div className="modal-content" onClick={e=>e.stopPropagation()}>
+          <h2>{t('my_builds')}</h2>
+          <table className="build-table">
+            <thead>
+              <tr>
+                <th>{t('build_title_col')}</th>
+                <th>{t('build_desc_col')}</th>
+                <th>{t('build_author_col')}</th>
+                <th>{t('build_updated_col')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {builds.map(b=>(
+                <tr key={b.id} onClick={()=>{onSelect(b.id); setModal(null);}}>
+                  <td>{b.title || b.id}</td>
+                  <td className="desc-cell">{b.description}</td>
+                  <td>{b.author}</td>
+                  <td>{b.updated}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       </div>
     );
@@ -828,9 +874,9 @@ function BuildPage(){
       const list = await r.json();
       if(!Array.isArray(list)) return;
       setModal({
-        options:list.map(b=>({value:b.id,label:b.title||b.id})),
-        onSelect:id=>{ loadBuild(id); },
-        hideCheck:true
+        buildList:true,
+        builds:list,
+        onSelect:id=>{ loadBuild(id); }
       });
     }catch(e){ console.error('load builds failed',e); }
   }
@@ -896,7 +942,7 @@ function BuildPage(){
       <main className="content-wrapper mt-4 flex-grow-1">
         <div style={{display:'flex',alignItems:'center',justifyContent:'space-between'}}>
           <h1 data-i18n="heading_build">Team builder</h1>
-          <div>
+          <div className="icon-bar">
             <button className="icon-btn" onClick={copyShare} data-i18n-title="share" title="Share"><i className="fa-solid fa-share-nodes"></i></button>
             <button className="icon-btn" onClick={() => setShowBuildSearch(true)} title="Search"><i className="fa-solid fa-magnifying-glass"></i></button>
             {window.keycloak?.authenticated && (
@@ -1124,6 +1170,7 @@ function BuildPage(){
         </div>
       </main>
       <SelectionModal />
+      <BuildListModal />
       <CapacityModal edit={capEdit} setEdit={setCapEdit} />
       <BuildSearchModal />
     </>

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -13,6 +13,8 @@
   "grid_view": "Rasteransicht",
   "table_view": "Tabellenansicht",
   "search_placeholder": "Pictos durchsuchen...",
+  "search_weapons_placeholder": "Search weapons...",
+  "search_outfits_placeholder": "Search outfits...",
   "defense": "Verteidigung",
   "speed": "Geschwindigkeit",
   "vitality": "Vitalität",
@@ -87,5 +89,11 @@
   "admin_capacities": "Fähigkeiten",
   "config_capacities": "Fähigkeiten konfigurieren",
   "edit": "Bearbeiten",
-  "show_labels": "i18n"
+  "show_labels": "i18n",
+  "my_builds": "My builds",
+  "search_builds": "Search builds",
+  "build_title_col": "Title",
+  "build_desc_col": "Description",
+  "build_author_col": "Author",
+  "build_updated_col": "Updated"
 }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -13,6 +13,8 @@
   "grid_view": "Grid view",
   "table_view": "Table view",
   "search_placeholder": "Search pictos by any field...",
+  "search_weapons_placeholder": "Search weapons...",
+  "search_outfits_placeholder": "Search outfits...",
   "defense": "Defense",
   "speed": "Speed",
   "vitality": "Vitality",
@@ -87,5 +89,11 @@
   "admin_capacities": "Capacities",
   "config_capacities": "Configure capacities",
   "edit": "Edit",
-  "show_labels": "i18n"
+  "show_labels": "i18n",
+  "my_builds": "My builds",
+  "search_builds": "Search builds",
+  "build_title_col": "Title",
+  "build_desc_col": "Description",
+  "build_author_col": "Author",
+  "build_updated_col": "Updated"
 }

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -13,6 +13,8 @@
   "grid_view": "Vista de cuadrícula",
   "table_view": "Vista de tabla",
   "search_placeholder": "Buscar pictos...",
+  "search_weapons_placeholder": "Buscar armas...",
+  "search_outfits_placeholder": "Buscar trajes...",
   "defense": "Defensa",
   "speed": "Velocidad",
   "vitality": "Vitalidad",
@@ -87,5 +89,11 @@
   "admin_capacities": "Capacidades",
   "config_capacities": "Configurar capacidades",
   "edit": "Editar",
-  "show_labels": "i18n"
+  "show_labels": "i18n",
+  "my_builds": "My builds",
+  "search_builds": "Search builds",
+  "build_title_col": "Title",
+  "build_desc_col": "Description",
+  "build_author_col": "Author",
+  "build_updated_col": "Updated"
 }

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -13,6 +13,8 @@
   "grid_view": "Vue grille",
   "table_view": "Vue tableau",
   "search_placeholder": "Rechercher un picto...",
+  "search_weapons_placeholder": "Rechercher une arme...",
+  "search_outfits_placeholder": "Rechercher une tenue...",
   "defense": "Défense",
   "speed": "Vitesse",
   "vitality": "Vitalité",
@@ -87,5 +89,11 @@
   "admin_capacities": "Capacités",
   "config_capacities": "Configurer les capacités",
   "edit": "Éditer",
-  "show_labels": "i18n"
+  "show_labels": "i18n",
+  "my_builds": "Mes builds",
+  "search_builds": "Rechercher des builds",
+  "build_title_col": "Titre",
+  "build_desc_col": "Description",
+  "build_author_col": "Auteur",
+  "build_updated_col": "Mise à jour"
 }

--- a/src/lang/it.json
+++ b/src/lang/it.json
@@ -13,6 +13,8 @@
   "grid_view": "Vista griglia",
   "table_view": "Vista tabella",
   "search_placeholder": "Cerca pictos...",
+  "search_weapons_placeholder": "Cerca armi...",
+  "search_outfits_placeholder": "Cerca outfit...",
   "defense": "Difesa",
   "speed": "Velocità",
   "vitality": "Vitalità",
@@ -87,5 +89,11 @@
   "admin_capacities": "Capacità",
   "config_capacities": "Configura capacità",
   "edit": "Modifica",
-  "show_labels": "i18n"
+  "show_labels": "i18n",
+  "my_builds": "My builds",
+  "search_builds": "Search builds",
+  "build_title_col": "Title",
+  "build_desc_col": "Description",
+  "build_author_col": "Author",
+  "build_updated_col": "Updated"
 }

--- a/src/lang/pl.json
+++ b/src/lang/pl.json
@@ -13,6 +13,8 @@
   "grid_view": "Widok siatki",
   "table_view": "Widok tabeli",
   "search_placeholder": "Wyszukaj picos według dowolnego pola ...",
+  "search_weapons_placeholder": "Search weapons...",
+  "search_outfits_placeholder": "Search outfits...",
   "defense": "Obrona",
   "speed": "Prędkość",
   "vitality": "Witalność",
@@ -87,5 +89,11 @@
   "admin_capacities": "Zdolności",
   "config_capacities": "Skonfiguruj zdolności",
   "edit": "Redagować",
-  "show_labels": "i18n"
+  "show_labels": "i18n",
+  "my_builds": "My builds",
+  "search_builds": "Search builds",
+  "build_title_col": "Title",
+  "build_desc_col": "Description",
+  "build_author_col": "Author",
+  "build_updated_col": "Updated"
 }

--- a/src/lang/pt.json
+++ b/src/lang/pt.json
@@ -13,6 +13,8 @@
   "grid_view": "Vista em grade",
   "table_view": "Vista em tabela",
   "search_placeholder": "Buscar pictos...",
+  "search_weapons_placeholder": "Buscar armas...",
+  "search_outfits_placeholder": "Buscar roupas...",
   "defense": "Defesa",
   "speed": "Velocidade",
   "vitality": "Vitalidade",
@@ -87,5 +89,11 @@
   "admin_capacities": "Capacidades",
   "config_capacities": "Configurar capacidades",
   "edit": "Editar",
-  "show_labels": "i18n"
+  "show_labels": "i18n",
+  "my_builds": "My builds",
+  "search_builds": "Search builds",
+  "build_title_col": "Title",
+  "build_desc_col": "Description",
+  "build_author_col": "Author",
+  "build_updated_col": "Updated"
 }


### PR DESCRIPTION
## Summary
- unify card padding and widen character spacing
- display build search and list popups using tables with headers
- add titles to build popups
- tweak team builder action button layout
- fix weapon/outfit search placeholders
- provide translation keys for new labels

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6888e6d542fc832ca2a686ab11efb4e0