### PR TITLE
Refactor header navigation

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -637,6 +637,18 @@ body[data-page="pictos"] .card.owned::after {
     font-size: 1.8em;
 }
 
+.navbar-nav button.nav-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: rgba(255,255,255,0.8);
+}
+.navbar-nav button.nav-link:hover,
+.navbar-nav button.nav-link:focus {
+  color: #fff;
+}
+
 .header-right {
   margin-left: auto;
   display: flex;
@@ -740,19 +752,25 @@ body {
 .dropdown { position: relative; }
 .dropdown-menu {
   position: absolute;
+  top: 100%;
+  left: 0;
   display: none;
   background: #23263a;
   border: 1px solid #3d4769;
   border-radius: 8px;
   padding: 4px 0;
   list-style: none;
-  margin: 0;
+  margin: 2px 0 0;
   min-width: 150px;
   z-index: 3002;
 }
 .dropdown-menu.right { right: 0; left: auto; }
 .dropdown-menu.show { display: block; }
-.dropdown-menu li, .dropdown-menu button, .dropdown-menu a, .dropdown-menu label {
+.dropdown-menu li,
+.dropdown-menu button,
+.dropdown-menu a,
+.dropdown-menu label,
+.dropdown-menu .lang-flag {
   display: block;
   padding: 6px 12px;
   color: #b6e4ff;
@@ -761,7 +779,11 @@ body {
   background: none;
   border: none;
 }
-.dropdown-menu li:hover, .dropdown-menu button:hover, .dropdown-menu a:hover, .dropdown-menu label:hover {
+.dropdown-menu li:hover,
+.dropdown-menu button:hover,
+.dropdown-menu a:hover,
+.dropdown-menu label:hover,
+.dropdown-menu .lang-flag:hover {
   background: #2c3142;
   color: #fff;
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -779,6 +779,12 @@ body {
   background: none;
   border: none;
 }
+.dropdown-menu button {
+  font: inherit;
+}
+.dropdown-menu .lang-flag {
+  text-align: center;
+}
 .dropdown-menu li:hover,
 .dropdown-menu button:hover,
 .dropdown-menu a:hover,

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -769,8 +769,7 @@ body {
 .dropdown-menu li,
 .dropdown-menu button,
 .dropdown-menu a,
-.dropdown-menu label,
-.dropdown-menu .lang-flag {
+.dropdown-menu label {
   display: block;
   padding: 6px 12px;
   color: #b6e4ff;
@@ -783,6 +782,11 @@ body {
   font: inherit;
 }
 .dropdown-menu .lang-flag {
+  display: block;
+  padding: 6px 12px;
+  color: #b6e4ff;
+  text-decoration: none;
+  white-space: nowrap;
   text-align: center;
 }
 .dropdown-menu li:hover,

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -711,6 +711,10 @@ body[data-page="pictos"] .card.owned::after {
   .navbar-nav .nav-item {
     margin: 10px 0;
   }
+  .nav-collapse .dropdown-menu {
+    right: 0;
+    left: auto;
+  }
   .header-right {
     margin-left: 0;
     justify-content: flex-end;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -737,6 +737,40 @@ body {
   opacity: 0.8;
 }
 
+.dropdown { position: relative; }
+.dropdown-menu {
+  position: absolute;
+  display: none;
+  background: #23263a;
+  border: 1px solid #3d4769;
+  border-radius: 8px;
+  padding: 4px 0;
+  list-style: none;
+  margin: 0;
+  min-width: 150px;
+  z-index: 3002;
+}
+.dropdown-menu.right { right: 0; left: auto; }
+.dropdown-menu.show { display: block; }
+.dropdown-menu li, .dropdown-menu button, .dropdown-menu a, .dropdown-menu label {
+  display: block;
+  padding: 6px 12px;
+  color: #b6e4ff;
+  text-decoration: none;
+  white-space: nowrap;
+  background: none;
+  border: none;
+}
+.dropdown-menu li:hover, .dropdown-menu button:hover, .dropdown-menu a:hover, .dropdown-menu label:hover {
+  background: #2c3142;
+  color: #fff;
+}
+.dropdown-divider {
+  height: 1px;
+  background: #3d4769;
+  margin: 4px 0;
+}
+
 .char-select{display:flex;gap:20px;flex-wrap:wrap;justify-content:center;margin-bottom:20px;}
 .char-select img{width:128px;height:128px;opacity:0.4;cursor:pointer;transition:opacity .2s;}
 .char-select img:hover{opacity:0.6;}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -788,13 +788,14 @@ body {
   text-decoration: none;
   white-space: nowrap;
   text-align: center;
+  cursor: pointer;
 }
 .dropdown-menu li:hover,
 .dropdown-menu button:hover,
 .dropdown-menu a:hover,
 .dropdown-menu label:hover,
 .dropdown-menu .lang-flag:hover {
-  background: #2c3142;
+  background-color: #2c3142;
   color: #fff;
 }
 .dropdown-divider {

--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -43,7 +43,15 @@ function updateLoginState(authenticated){
     }
     btn.dataset.i18nTitle='logout';
     btn.title=t('logout');
-    btn.onclick=()=>keycloak.logout();
+    btn.onclick=null;
+    const saveBtn=document.getElementById('saveDataBtn');
+    if(saveBtn) saveBtn.onclick=()=>window.saveSiteData && window.saveSiteData();
+    const acc=document.getElementById('accountLink');
+    if(acc) acc.href = keycloak.createAccountUrl();
+    const logoutItem=document.getElementById('logoutItem');
+    if(logoutItem) logoutItem.onclick=()=>keycloak.logout();
+    const menu=document.getElementById('loginMenu');
+    if(menu) menu.style.display='none';
   }else{
     stopTokenRefresh();
     const adminLink=document.getElementById('adminNav');
@@ -54,7 +62,15 @@ function updateLoginState(authenticated){
     btn.innerHTML='<i class="fa-solid fa-user"></i>';
     btn.dataset.i18nTitle='login';
     btn.title=t('login');
-  btn.onclick=()=>keycloak.login();
+  btn.onclick=null;
+  const saveBtn=document.getElementById('saveDataBtn');
+  if(saveBtn) saveBtn.onclick=null;
+  const acc=document.getElementById('accountLink');
+  if(acc) acc.removeAttribute('href');
+  const logoutItem=document.getElementById('logoutItem');
+  if(logoutItem) logoutItem.onclick=null;
+  const menu=document.getElementById('loginMenu');
+  if(menu) menu.style.display='none';
   }
   if(window.loadSiteData){
     loadSiteData();

--- a/src/js/components.jsx
+++ b/src/js/components.jsx
@@ -26,7 +26,41 @@ const Header = () => {
   const [userOpen, setUserOpen] = useState(false);
   const [lang, setLang] = useState(window.currentLang || 'en');
   const fileRef = useRef();
-  const closeMenu = () => { setMenuOpen(false); setInvOpen(false); };
+  const closeMenu = () => {
+    setMenuOpen(false);
+    setInvOpen(false);
+    setLangOpen(false);
+    setUserOpen(false);
+  };
+
+  const toggleMenu = () => {
+    setMenuOpen(o => !o);
+    setInvOpen(false);
+    setLangOpen(false);
+    setUserOpen(false);
+  };
+
+  const toggleInv = () => {
+    setInvOpen(o => !o);
+    setLangOpen(false);
+    setUserOpen(false);
+  };
+
+  const toggleLang = () => {
+    setLangOpen(o => !o);
+    setInvOpen(false);
+    setUserOpen(false);
+  };
+
+  const toggleUser = () => {
+    if(window.keycloak?.authenticated){
+      setUserOpen(o => !o);
+      setInvOpen(false);
+      setLangOpen(false);
+    }else{
+      window.keycloak?.login();
+    }
+  };
   React.useEffect(() => {
     const h = e => setLang(e.detail);
     window.addEventListener('langchange', h);
@@ -50,11 +84,11 @@ const Header = () => {
           <img src="resources/images/icons/icon_base_maxsize.png" alt="Clair Obscur logo" className="site-logo"/>
           Clair Obscur Helper
         </NavLink>
-        <button className="burger-btn" onClick={() => setMenuOpen(o => !o)}><i className="fa-solid fa-bars"></i></button>
+        <button className="burger-btn" onClick={toggleMenu}><i className="fa-solid fa-bars"></i></button>
         <div className={`nav-collapse${menuOpen ? ' show' : ''}`}>
           <ul className="navbar-nav flex-row">
             <li className="nav-item dropdown">
-              <button className="nav-link dropdown-toggle" onClick={() => setInvOpen(o=>!o)} data-i18n="nav_inventories">Inventories</button>
+              <button className="nav-link dropdown-toggle" onClick={toggleInv} data-i18n="nav_inventories">Inventories</button>
               <ul className={`dropdown-menu${invOpen ? ' show' : ''}`}
                 onClick={() => setInvOpen(false)}>
                 <li><NavLink className="nav-link" to="/pictos" onClick={closeMenu} data-i18n="nav_pictos">Pictos inventory</NavLink></li>
@@ -72,7 +106,7 @@ const Header = () => {
               <input type="file" ref={fileRef} accept="application/json" style={{display:'none'}} onChange={handleFileChange}/>
             </div>
           <div className={`dropdown right${langOpen ? ' show' : ''}`}>
-            <button className="icon-btn" onClick={() => setLangOpen(o=>!o)}>
+            <button className="icon-btn" onClick={toggleLang}>
               <span
                 className={`lang-flag fi fi-${lang==='en'?'gb':lang}`}
                 data-lang={lang}
@@ -89,7 +123,7 @@ const Header = () => {
             </ul>
           </div>
           <div className={`dropdown right${userOpen ? ' show' : ''}`}>
-            <button className="icon-btn" id="loginBtn" data-i18n-title="login" title="Login" onClick={() => { if(window.keycloak?.authenticated){ setUserOpen(o=>!o); }else{ window.keycloak?.login(); } }}><i className="fa-solid fa-user"></i></button>
+            <button className="icon-btn" id="loginBtn" data-i18n-title="login" title="Login" onClick={toggleUser}><i className="fa-solid fa-user"></i></button>
             <div className="dropdown-menu right" id="loginMenu" style={{display:userOpen?'block':'none'}}>
               <button className="dropdown-item" id="saveDataBtn" data-i18n="save">Save</button>
               <a className="dropdown-item" id="accountLink" target="_blank" rel="noopener noreferrer" data-i18n="my_account">Account</a>

--- a/src/js/components.jsx
+++ b/src/js/components.jsx
@@ -66,6 +66,14 @@ const Header = () => {
     window.addEventListener('langchange', h);
     return () => window.removeEventListener('langchange', h);
   }, []);
+  React.useEffect(() => {
+    const handleClick = e => {
+      const nav = document.querySelector('.navbar');
+      if(nav && !nav.contains(e.target)) closeMenu();
+    };
+    document.addEventListener('click', handleClick);
+    return () => document.removeEventListener('click', handleClick);
+  }, [menuOpen, invOpen, langOpen, userOpen]);
   const handleDownload = () => {
     if(window.downloadSiteData) window.downloadSiteData();
   };

--- a/src/js/components.jsx
+++ b/src/js/components.jsx
@@ -73,7 +73,10 @@ const Header = () => {
             </div>
           <div className={`dropdown right${langOpen ? ' show' : ''}`}>
             <button className="icon-btn" onClick={() => setLangOpen(o=>!o)}>
-              <span className={`lang-flag fi fi-${lang==='en'?'gb':lang}`}></span>
+              <span
+                className={`lang-flag fi fi-${lang==='en'?'gb':lang}`}
+                data-lang={lang}
+              ></span>
             </button>
             <ul className={`dropdown-menu right${langOpen ? ' show' : ''}`} onClick={()=>setLangOpen(false)}>
               <li><span className="lang-flag fi fi-fr" data-lang="fr" id="frFlag"></span></li>

--- a/src/js/components.jsx
+++ b/src/js/components.jsx
@@ -21,8 +21,17 @@ function sanitizeRow(row){
 
 const Header = () => {
   const [menuOpen, setMenuOpen] = useState(false);
+  const [invOpen, setInvOpen] = useState(false);
+  const [langOpen, setLangOpen] = useState(false);
+  const [userOpen, setUserOpen] = useState(false);
+  const [lang, setLang] = useState(window.currentLang || 'en');
   const fileRef = useRef();
-  const closeMenu = () => setMenuOpen(false);
+  const closeMenu = () => { setMenuOpen(false); setInvOpen(false); };
+  React.useEffect(() => {
+    const h = e => setLang(e.detail);
+    window.addEventListener('langchange', h);
+    return () => window.removeEventListener('langchange', h);
+  }, []);
   const handleDownload = () => {
     if(window.downloadSiteData) window.downloadSiteData();
   };
@@ -44,9 +53,15 @@ const Header = () => {
         <button className="burger-btn" onClick={() => setMenuOpen(o => !o)}><i className="fa-solid fa-bars"></i></button>
         <div className={`nav-collapse${menuOpen ? ' show' : ''}`}>
           <ul className="navbar-nav flex-row">
-            <li className="nav-item"><NavLink className="nav-link" to="/pictos" onClick={closeMenu} data-i18n="nav_pictos">Pictos inventory</NavLink></li>
-            <li className="nav-item"><NavLink className="nav-link" to="/weapons" onClick={closeMenu} data-i18n="nav_weapons">Weapons inventory</NavLink></li>
-            <li className="nav-item"><NavLink className="nav-link" to="/outfits" onClick={closeMenu} data-i18n="nav_outfits">Outfits inventory</NavLink></li>
+            <li className="nav-item dropdown">
+              <button className="nav-link dropdown-toggle" onClick={() => setInvOpen(o=>!o)} data-i18n="nav_inventories">Inventories</button>
+              <ul className={`dropdown-menu${invOpen ? ' show' : ''}`}
+                onClick={() => setInvOpen(false)}>
+                <li><NavLink className="nav-link" to="/pictos" onClick={closeMenu} data-i18n="nav_pictos">Pictos inventory</NavLink></li>
+                <li><NavLink className="nav-link" to="/weapons" onClick={closeMenu} data-i18n="nav_weapons">Weapons inventory</NavLink></li>
+                <li><NavLink className="nav-link" to="/outfits" onClick={closeMenu} data-i18n="nav_outfits">Outfits inventory</NavLink></li>
+              </ul>
+            </li>
             <li className="nav-item"><NavLink className="nav-link" to="/build" onClick={closeMenu} data-i18n="nav_build">Team builder</NavLink></li>
             <li className="nav-item" id="adminNav" style={{display:'none'}}><NavLink className="nav-link" to="/admin" onClick={closeMenu} data-i18n="nav_admin">Admin</NavLink></li>
           </ul>
@@ -56,21 +71,34 @@ const Header = () => {
               <button className="icon-btn" id="uploadBtn" data-i18n-title="upload" title="Upload" onClick={handleUploadClick}><img src="resources/images/icons/buttons/upload.png" alt=""/></button>
               <input type="file" ref={fileRef} accept="application/json" style={{display:'none'}} onChange={handleFileChange}/>
             </div>
-          <div className="lang-flags">
-            <span className="lang-flag fi fi-fr" data-lang="fr" id="frFlag"></span>
-            <span className="lang-flag fi fi-gb" data-lang="en" id="enFlag"></span>
-            <span className="lang-flag fi fi-de" data-lang="de" id="deFlag"></span>
-            <span className="lang-flag fi fi-es" data-lang="es" id="esFlag"></span>
-            <span className="lang-flag fi fi-it" data-lang="it" id="itFlag"></span>
-            <span className="lang-flag fi fi-pl" data-lang="pl" id="plFlag"></span>
-            <span className="lang-flag fi fi-pt" data-lang="pt" id="ptFlag"></span>
+          <div className={`dropdown right${langOpen ? ' show' : ''}`}>
+            <button className="icon-btn" onClick={() => setLangOpen(o=>!o)}>
+              <span className={`lang-flag fi fi-${lang==='en'?'gb':lang}`}></span>
+            </button>
+            <div className={`dropdown-menu right${langOpen ? ' show' : ''}`} onClick={()=>setLangOpen(false)}>
+              <span className="lang-flag fi fi-fr" data-lang="fr" id="frFlag"></span>
+              <span className="lang-flag fi fi-gb" data-lang="en" id="enFlag"></span>
+              <span className="lang-flag fi fi-de" data-lang="de" id="deFlag"></span>
+              <span className="lang-flag fi fi-es" data-lang="es" id="esFlag"></span>
+              <span className="lang-flag fi fi-it" data-lang="it" id="itFlag"></span>
+              <span className="lang-flag fi fi-pt" data-lang="pt" id="ptFlag"></span>
+              <span className="lang-flag fi fi-pl" data-lang="pl" id="plFlag"></span>
+            </div>
           </div>
-          <div className="icon-sep"></div>
-          <label className="toggle-btn" id="labelToggle" style={{display:'none'}}>
-            <input type="checkbox" id="labelToggleInput" />
-            <span data-i18n="show_labels">Show labels</span>
-          </label>
-          <button className="icon-btn" id="loginBtn" data-i18n-title="login" title="Login"><i className="fa-solid fa-user"></i></button>
+          <div className={`dropdown right${userOpen ? ' show' : ''}`}>
+            <button className="icon-btn" id="loginBtn" data-i18n-title="login" title="Login" onClick={() => { if(window.keycloak?.authenticated){ setUserOpen(o=>!o); }else{ window.keycloak?.login(); } }}><i className="fa-solid fa-user"></i></button>
+            <div className="dropdown-menu right" id="loginMenu" style={{display:userOpen?'block':'none'}}>
+              <button className="dropdown-item" id="saveDataBtn" data-i18n="save">Save</button>
+              <a className="dropdown-item" id="accountLink" target="_blank" rel="noopener noreferrer" data-i18n="my_account">Account</a>
+              <div className="dropdown-divider"></div>
+              <label className="toggle-btn" id="labelToggle" style={{display:'none'}}>
+                <input type="checkbox" id="labelToggleInput" />
+                <span data-i18n="show_labels">i18n</span>
+              </label>
+              <div className="dropdown-divider"></div>
+              <button className="dropdown-item" id="logoutItem" data-i18n="logout">Logout</button>
+            </div>
+          </div>
         </div>
         </div>
       </div>

--- a/src/js/components.jsx
+++ b/src/js/components.jsx
@@ -75,15 +75,15 @@ const Header = () => {
             <button className="icon-btn" onClick={() => setLangOpen(o=>!o)}>
               <span className={`lang-flag fi fi-${lang==='en'?'gb':lang}`}></span>
             </button>
-            <div className={`dropdown-menu right${langOpen ? ' show' : ''}`} onClick={()=>setLangOpen(false)}>
-              <span className="lang-flag fi fi-fr" data-lang="fr" id="frFlag"></span>
-              <span className="lang-flag fi fi-gb" data-lang="en" id="enFlag"></span>
-              <span className="lang-flag fi fi-de" data-lang="de" id="deFlag"></span>
-              <span className="lang-flag fi fi-es" data-lang="es" id="esFlag"></span>
-              <span className="lang-flag fi fi-it" data-lang="it" id="itFlag"></span>
-              <span className="lang-flag fi fi-pt" data-lang="pt" id="ptFlag"></span>
-              <span className="lang-flag fi fi-pl" data-lang="pl" id="plFlag"></span>
-            </div>
+            <ul className={`dropdown-menu right${langOpen ? ' show' : ''}`} onClick={()=>setLangOpen(false)}>
+              <li><span className="lang-flag fi fi-fr" data-lang="fr" id="frFlag"></span></li>
+              <li><span className="lang-flag fi fi-gb" data-lang="en" id="enFlag"></span></li>
+              <li><span className="lang-flag fi fi-de" data-lang="de" id="deFlag"></span></li>
+              <li><span className="lang-flag fi fi-es" data-lang="es" id="esFlag"></span></li>
+              <li><span className="lang-flag fi fi-it" data-lang="it" id="itFlag"></span></li>
+              <li><span className="lang-flag fi fi-pt" data-lang="pt" id="ptFlag"></span></li>
+              <li><span className="lang-flag fi fi-pl" data-lang="pl" id="plFlag"></span></li>
+            </ul>
           </div>
           <div className={`dropdown right${userOpen ? ' show' : ''}`}>
             <button className="icon-btn" id="loginBtn" data-i18n-title="login" title="Login" onClick={() => { if(window.keycloak?.authenticated){ setUserOpen(o=>!o); }else{ window.keycloak?.login(); } }}><i className="fa-solid fa-user"></i></button>

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -95,5 +95,7 @@
   "build_title_col": "Title",
   "build_desc_col": "Description",
   "build_author_col": "Author",
-  "build_updated_col": "Updated"
+  "build_updated_col": "Updated",
+  "nav_inventories": "Inventare",
+  "my_account": "Mein Konto"
 }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -95,5 +95,7 @@
   "build_title_col": "Title",
   "build_desc_col": "Description",
   "build_author_col": "Author",
-  "build_updated_col": "Updated"
+  "build_updated_col": "Updated",
+  "nav_inventories": "Inventories",
+  "my_account": "My Account"
 }

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -95,5 +95,7 @@
   "build_title_col": "Title",
   "build_desc_col": "Description",
   "build_author_col": "Author",
-  "build_updated_col": "Updated"
+  "build_updated_col": "Updated",
+  "nav_inventories": "Inventarios",
+  "my_account": "Mi cuenta"
 }

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -95,5 +95,7 @@
   "build_title_col": "Titre",
   "build_desc_col": "Description",
   "build_author_col": "Auteur",
-  "build_updated_col": "Mise à jour"
+  "build_updated_col": "Mise à jour",
+  "nav_inventories": "Inventaires",
+  "my_account": "Mon compte"
 }

--- a/src/lang/it.json
+++ b/src/lang/it.json
@@ -95,5 +95,7 @@
   "build_title_col": "Title",
   "build_desc_col": "Description",
   "build_author_col": "Author",
-  "build_updated_col": "Updated"
+  "build_updated_col": "Updated",
+  "nav_inventories": "Inventari",
+  "my_account": "Il mio account"
 }

--- a/src/lang/pl.json
+++ b/src/lang/pl.json
@@ -95,5 +95,7 @@
   "build_title_col": "Title",
   "build_desc_col": "Description",
   "build_author_col": "Author",
-  "build_updated_col": "Updated"
+  "build_updated_col": "Updated",
+  "nav_inventories": "Inwentarze",
+  "my_account": "Moje konto"
 }

--- a/src/lang/pt.json
+++ b/src/lang/pt.json
@@ -95,5 +95,7 @@
   "build_title_col": "Title",
   "build_desc_col": "Description",
   "build_author_col": "Author",
-  "build_updated_col": "Updated"
+  "build_updated_col": "Updated",
+  "nav_inventories": "Inventários",
+  "my_account": "Minha conta"
 }


### PR DESCRIPTION
## Summary
- organize nav items in dropdown lists
- support language and login dropdowns
- update login logic for new dropdown
- style dropdown menus
- add translations for new labels

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688999d41124832c9e351014976ec946