### PR TITLE
Improve collapsed menu style

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -711,6 +711,20 @@ body[data-page="pictos"] .card.owned::after {
   .navbar-nav .nav-item {
     margin: 10px 0;
   }
+  .nav-collapse .nav-link {
+    display: block;
+    padding: 6px 12px;
+    color: #b6e4ff;
+    text-decoration: none;
+    white-space: nowrap;
+    background: none;
+    border: none;
+  }
+  .nav-collapse .nav-link:hover,
+  .nav-collapse .nav-link:focus {
+    background-color: #2c3142;
+    color: #fff;
+  }
   .nav-collapse .dropdown-menu {
     right: 0;
     left: auto;


### PR DESCRIPTION
## Summary
- tweak mobile nav styles so top-level links appear like dropdown entries

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889c4f5dd40832c9997fca171ca6d04