### PR TITLE
Update build search placeholder defaults

### DIFF
--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -550,14 +550,20 @@ function BuildPage(){
               </tr>
             </thead>
             <tbody>
-              {results.map(b=>(
-                <tr key={b.id} onClick={()=>{loadBuild(b.id); setShowBuildSearch(false);}}>
-                  <td>{b.title || b.id}</td>
-                  <td className="desc-cell">{b.description}</td>
-                  <td>{b.author}</td>
-                  <td>{b.updated}</td>
-                </tr>
-              ))}
+              {results.map(b=>{
+                const title = b.title && b.title.trim() ? b.title : 'Pas de titre';
+                const desc = b.description && b.description.trim() ? b.description : 'Pas de description';
+                const author = b.author && b.author.trim() ? b.author : 'Anonyme';
+                const updated = b.updated && b.updated.trim() ? b.updated : '-';
+                return (
+                  <tr key={b.id} onClick={()=>{loadBuild(b.id); setShowBuildSearch(false);}}>
+                    <td>{title}</td>
+                    <td className="desc-cell">{desc}</td>
+                    <td>{author}</td>
+                    <td>{updated}</td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>
@@ -582,14 +588,20 @@ function BuildPage(){
               </tr>
             </thead>
             <tbody>
-              {builds.map(b=>(
-                <tr key={b.id} onClick={()=>{onSelect(b.id); setModal(null);}}>
-                  <td>{b.title || b.id}</td>
-                  <td className="desc-cell">{b.description}</td>
-                  <td>{b.author}</td>
-                  <td>{b.updated}</td>
-                </tr>
-              ))}
+              {builds.map(b=>{
+                const title = b.title && b.title.trim() ? b.title : 'Pas de titre';
+                const desc = b.description && b.description.trim() ? b.description : 'Pas de description';
+                const author = b.author && b.author.trim() ? b.author : 'Anonyme';
+                const updated = b.updated && b.updated.trim() ? b.updated : '-';
+                return (
+                  <tr key={b.id} onClick={()=>{onSelect(b.id); setModal(null);}}>
+                    <td>{title}</td>
+                    <td className="desc-cell">{desc}</td>
+                    <td>{author}</td>
+                    <td>{updated}</td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
## Summary
- show default text when build metadata fields are missing

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6889c7879330832cb789b2c99317a73c