### PR TITLE
Fix deep link loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ so everything works from the `dist` folder alone:
 ```bash
 npm run build
 ```
+The build script also creates a `404.html` copy of `index.html` so that static
+hosts can serve it for unknown routes. This allows deep links such as
+`/build/<id>` to load the application correctly without extra server
+configuration.
 
 ## Configuration
 

--- a/build.js
+++ b/build.js
@@ -156,6 +156,10 @@ async function main(){
   indexHtml = indexHtml.replace(/<script type="text\/babel" src="js\/app.jsx"><\/script>/, '<script src="js/app.js"></script>');
   fs.writeFileSync(indexPath, indexHtml);
 
+  // provide a fallback page for static hosting so deep links work
+  const notFoundPath = path.join(distDir, '404.html');
+  fs.writeFileSync(notFoundPath, indexHtml);
+
   console.log(`Built dist to ${distDir}`);
 }
 


### PR DESCRIPTION
## Summary
- create 404.html during build so direct links like `/build/<id>` work on static hosts
- document the 404 fallback in README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a5f94fc70832c84e68752413a56bd