### PR TITLE
Add manual save button

### DIFF
--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -46,6 +46,11 @@ function updateLoginState(authenticated){
     btn.onclick=null;
     const saveBtn=document.getElementById('saveDataBtn');
     if(saveBtn) saveBtn.onclick=()=>window.saveSiteData && window.saveSiteData();
+    const manualBtn=document.getElementById('manualSaveBtn');
+    if(manualBtn){
+      manualBtn.style.display='inline-block';
+      manualBtn.onclick=()=>window.saveSiteData && window.saveSiteData();
+    }
     const acc=document.getElementById('accountLink');
     if(acc) acc.href = keycloak.createAccountUrl();
     const logoutItem=document.getElementById('logoutItem');
@@ -65,6 +70,11 @@ function updateLoginState(authenticated){
   btn.onclick=null;
   const saveBtn=document.getElementById('saveDataBtn');
   if(saveBtn) saveBtn.onclick=null;
+  const manualBtn=document.getElementById('manualSaveBtn');
+  if(manualBtn){
+    manualBtn.style.display='none';
+    manualBtn.onclick=null;
+  }
   const acc=document.getElementById('accountLink');
   if(acc) acc.removeAttribute('href');
   const logoutItem=document.getElementById('logoutItem');

--- a/src/js/components.jsx
+++ b/src/js/components.jsx
@@ -78,6 +78,9 @@ const Header = () => {
     if(window.downloadSiteData) window.downloadSiteData();
   };
   const handleUploadClick = () => fileRef.current?.click();
+  const handleSave = () => {
+    if(window.saveSiteData) window.saveSiteData();
+  };
   const handleFileChange = e => {
     const file = e.target.files?.[0];
     if(file && window.handleSiteUpload) {
@@ -111,6 +114,7 @@ const Header = () => {
             <div className="icon-bar header-actions">
               <button className="icon-btn" id="downloadBtn" data-i18n-title="download" title="Download" onClick={handleDownload}><img src="resources/images/icons/buttons/download.png" alt=""/></button>
               <button className="icon-btn" id="uploadBtn" data-i18n-title="upload" title="Upload" onClick={handleUploadClick}><img src="resources/images/icons/buttons/upload.png" alt=""/></button>
+              <button className="icon-btn" id="manualSaveBtn" data-i18n-title="save" title="Save" style={{display:'none'}} onClick={handleSave}><img src="resources/images/icons/buttons/save.png" alt=""/></button>
               <input type="file" ref={fileRef} accept="application/json" style={{display:'none'}} onChange={handleFileChange}/>
             </div>
           <div className={`dropdown right${langOpen ? ' show' : ''}`}>

--- a/src/js/siteStorage.js
+++ b/src/js/siteStorage.js
@@ -47,7 +47,7 @@ function setSavedItems(key, arr, charId) {
   } else {
     siteData[key] = Array.from(new Set(arr));
   }
-  saveSiteData();
+  if(!window.keycloak?.authenticated) saveSiteData();
 }
 
 async function saveSiteData() {
@@ -90,7 +90,7 @@ function handleSiteUpload(file) {
         if(Array.isArray(obj.weapons) || typeof obj.weapons === 'object') siteData.weapons = obj.weapons;
         if(Array.isArray(obj.outfits)) siteData.outfits = obj.outfits;
       }
-      saveSiteData();
+      if(!window.keycloak?.authenticated) saveSiteData();
       notifyPages();
     } catch(err) {
       /* ignore */
@@ -113,7 +113,9 @@ function notifyPages(){
 }
 
 document.addEventListener('DOMContentLoaded', loadSiteData);
-window.addEventListener('beforeunload', saveSiteData);
+window.addEventListener('beforeunload', () => {
+  if(!window.keycloak?.authenticated) saveSiteData();
+});
 
 window.getSavedItems = getSavedItems;
 window.setSavedItems = setSavedItems;


### PR DESCRIPTION
## Summary
- disable automatic saves when authenticated
- add manual save button in the header next to download/upload
- show/hide the manual save button based on login state

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688acc43f748832cbe1efe006fb40f80