### PR TITLE
Improve team builder meta display

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1298,13 +1298,15 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 .tip-hover .tooltip-text{display:none;position:absolute;background:rgba(0,0,0,0.8);color:#fff;padding:4px 8px;border-radius:4px;top:-6px;left:50%;transform:translate(-50%,-100%);white-space:pre-line;z-index:1000;max-width:240px;min-width:160px;}
 .tip-hover:hover .tooltip-text{display:block;}
 
-.build-info, .build-info-edit{
-  margin: 10px 0;
-  padding: 10px;
+.build-info{margin:10px 0;text-align:center;}
+.build-info-edit{
+  margin:10px 0;
+  padding:10px;
   background:#2a2d40;
   border:1px solid #444;
   border-radius:4px;
 }
+.build-info .build-desc{display:inline-block;text-align:left;max-width:600px;}
 .build-info-edit input,
 .build-info-edit textarea{
   display:block;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -578,6 +578,21 @@ body[data-page="pictos"] .card.owned::after {
 }
 #editModal { z-index: 1200; }
 #editModal .modal-content { max-width: 600px; }
+#modalSelect.lumina-modal .modal-content {
+  width: 70%;
+  max-width: none;
+}
+@media (max-width:800px) {
+  #modalSelect.lumina-modal .modal-content { width: 95%; }
+}
+#modalSelect.lumina-modal .modal-options.grid {
+  grid-template-columns: repeat(3, 1fr);
+}
+#modalSelect.lumina-modal .modal-option.grid span {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 #editModal label { display:block; margin-top:6px; }
 #editModal input, #editModal textarea, #editModal select { width:100%; margin-bottom:6px; }
 #editModal textarea{ resize:vertical; }

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -1055,7 +1055,7 @@ function BuildPage(){
           <div className="build-info">
             <h2>{buildMeta.title && buildMeta.title.trim() ? buildMeta.title : 'No Title'}</h2>
             <div>Recommended level: {buildMeta.level || 0}</div>
-            <div>{buildMeta.description}</div>
+            <div className="build-desc" dangerouslySetInnerHTML={{__html:(buildMeta.description||'').replace(/\n/g,'<br />')}} />
           </div>
         )}
         {editMeta && (

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -461,7 +461,7 @@ function BuildPage(){
 
   function SelectionModal(){
     if(!modal || !modal.options) return null;
-    const {options,onSelect,multi,values,search,grid,hideCheck}=modal;
+    const {options,onSelect,multi,values,search,grid,hideCheck,type}=modal;
     const [local,setLocal]=React.useState(multi?values.slice():values||'');
     const [term,setTerm]=React.useState('');
     const list=search?options.filter(o=>{
@@ -469,8 +469,9 @@ function BuildPage(){
       return txt.includes(term.toLowerCase());
     }):options;
     function apply(){ onSelect(local); setModal(null); }
+    const extraClass = type === 'luminaSubs' ? ' lumina-modal' : '';
     return (
-      <div className="modal" onClick={()=>setModal(null)} id="modalSelect">
+      <div className={`modal${extraClass}`} onClick={()=>setModal(null)} id="modalSelect">
         <div className="modal-content" onClick={e=>e.stopPropagation()}>
           {search && (
             <input
@@ -485,7 +486,7 @@ function BuildPage(){
             <>
               <div className={`modal-options${grid?' grid':''}`}>
                 {list.map(o => (
-                  <label key={o.value} className={`modal-option${grid?' grid':''}${hideCheck?' hide-check':''}`}>
+                  <label key={o.value} className={`modal-option${grid?' grid':''}${hideCheck?' hide-check':''}${type==='luminaSubs'?' tip-hover':''}`}>
                     {o.icon && <img src={o.icon} alt="" />}
                     <input
                       type="checkbox"
@@ -499,6 +500,9 @@ function BuildPage(){
                       }}
                     />
                     <span>{o.label}</span>
+                    {type==='luminaSubs' && o.desc && (
+                      <span className="tooltip-text" dangerouslySetInnerHTML={{__html: window.formatGameString(o.desc)}} />
+                    )}
                   </label>
                 ))}
               </div>
@@ -513,7 +517,7 @@ function BuildPage(){
               {list.map(o => (
                 <div
                   key={o.value}
-                  className={`modal-option${grid?' grid':''}${hideCheck?' hide-check':''}`}
+                  className={`modal-option${grid?' grid':''}${hideCheck?' hide-check':''}${type==='luminaSubs'?' tip-hover':''}`}
                   onClick={() => {
                     onSelect(o.value);
                     setModal(null);
@@ -521,6 +525,9 @@ function BuildPage(){
                 >
                   {o.icon && <img src={o.icon} alt="" />}
                   <span>{o.label}</span>
+                  {type==='luminaSubs' && o.desc && (
+                    <span className="tooltip-text" dangerouslySetInnerHTML={{__html: window.formatGameString(o.desc)}} />
+                  )}
                 </div>
               ))}
             </div>
@@ -879,7 +886,8 @@ function BuildPage(){
         values: baseValues,
         search: true,
         grid: true,
-        hideCheck: true
+        hideCheck: true,
+        type: 'luminaSubs'
       });
     }else{
       setModal({
@@ -889,7 +897,8 @@ function BuildPage(){
         values: baseValues,
         search: true,
         grid: true,
-        hideCheck: true
+        hideCheck: true,
+        type: 'luminaSubs'
       });
     }
   }
@@ -1026,25 +1035,27 @@ function BuildPage(){
     <>
       <main className="content-wrapper mt-4 flex-grow-1">
         <div style={{display:'flex',alignItems:'center',justifyContent:'space-between'}}>
-          <h1 data-i18n="heading_build">Team builder</h1>
+          <div style={{display:'flex',alignItems:'center',gap:'10px'}}>
+            <h1 data-i18n="heading_build">Team builder</h1>
+            {editMode && (
+              <button className="icon-btn" onClick={toggleEdit} title="Edit"><i className="fa-solid fa-pen"></i></button>
+            )}
+          </div>
           <div className="icon-bar">
             <button className="icon-btn" onClick={copyShare} data-i18n-title="share" title="Share"><i className="fa-solid fa-share-nodes"></i></button>
             <button className="icon-btn" onClick={() => setShowBuildSearch(true)} title="Search"><i className="fa-solid fa-magnifying-glass"></i></button>
             <button className="icon-btn" onClick={() => setEditMode(e=>!e)} data-i18n-title="edit_mode" title="Edit mode"><i className={`fa-solid ${editMode?'fa-lock-open':'fa-lock'}`}></i></button>
             <button className="icon-btn" onClick={clearBuild} data-i18n-title="clear_build" title="Clear build"><i className="fa-solid fa-broom"></i></button>
             {window.keycloak?.authenticated && (
-              <>
-                <button className="icon-btn" onClick={openBuildList} title="Builds"><i className="fa-solid fa-list"></i></button>
-                <button className="icon-btn" onClick={toggleEdit} title="Edit"><i className="fa-solid fa-pen"></i></button>
-              </>
+              <button className="icon-btn" onClick={openBuildList} title="Builds"><i className="fa-solid fa-list"></i></button>
             )}
           </div>
         </div>
-        {buildMeta.id && !editMeta && (
+        {!editMeta && (
           <div className="build-info">
-            <h2>{buildMeta.title}</h2>
+            <h2>{buildMeta.title && buildMeta.title.trim() ? buildMeta.title : 'No Title'}</h2>
+            <div>Recommended level: {buildMeta.level || 0}</div>
             <div>{buildMeta.description}</div>
-            <div>Recommended level: {buildMeta.level}</div>
           </div>
         )}
         {editMeta && (


### PR DESCRIPTION
## Summary
- always show build meta title, level and description
- only show edit meta button in header when edit mode is active
- enlarge lumina popup and show tooltips on hover
- display lumina options on three columns with ellipsis text

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688af8cb3904832c8b80d5f42492a565