### PR TITLE
Add suggestion form and admin page

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -613,7 +613,7 @@ body[data-page="pictos"] .card.owned::after {
   transform: translateY(0);
 }
 
-  footer {
+footer {
     position: fixed;
     bottom: 0;
     left: 0;
@@ -622,7 +622,15 @@ body[data-page="pictos"] .card.owned::after {
     background: url('../resources/images/background_site_header_footer.png') repeat-x center center/100% auto;
     z-index: 3000;
     padding: 28px 0 18px;
-  }
+}
+
+.footer-link {
+  color: inherit;
+  text-decoration: none;
+}
+.footer-link:hover {
+  text-decoration: underline;
+}
 
 
   .navbar {
@@ -1352,4 +1360,32 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
   white-space:nowrap;
   overflow:hidden;
   text-overflow:ellipsis;
+}
+
+.suggest-form{
+  max-width:600px;
+  margin:20px auto;
+}
+.suggest-form input,
+.suggest-form textarea{
+  display:block;
+  width:100%;
+  margin-bottom:10px;
+  padding:6px;
+  box-sizing:border-box;
+}
+.suggest-form button{
+  display:block;
+  margin:auto;
+}
+
+.admin-suggestions{
+  max-width:800px;
+  margin:20px auto;
+}
+.admin-suggestions .suggest-item{
+  border:1px solid #444;
+  padding:10px;
+  margin-bottom:10px;
+  border-radius:4px;
 }

--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -28,6 +28,7 @@ function updateLoginState(authenticated){
     btn.classList.add('user-name');
     btn.textContent=username;
     const adminLink=document.getElementById('adminNav');
+    const adminSug=document.getElementById('adminSuggestionsNav');
     const labelToggle=document.getElementById('labelToggle');
     const existing=btn.querySelector('.admin-crown');
     if(existing) existing.remove();
@@ -36,9 +37,11 @@ function updateLoginState(authenticated){
       icon.className='fa-solid fa-crown admin-crown';
       btn.appendChild(icon);
       if(adminLink) adminLink.style.display='block';
+      if(adminSug) adminSug.style.display='block';
       if(labelToggle){ labelToggle.style.display='inline-block'; if(window.bindShowLabelsToggle) window.bindShowLabelsToggle(); }
     }else{
       if(adminLink) adminLink.style.display='none';
+      if(adminSug) adminSug.style.display='none';
       if(labelToggle) labelToggle.style.display='none';
     }
     btn.dataset.i18nTitle='logout';
@@ -60,8 +63,10 @@ function updateLoginState(authenticated){
   }else{
     stopTokenRefresh();
     const adminLink=document.getElementById('adminNav');
+    const adminSug=document.getElementById('adminSuggestionsNav');
     const labelToggle=document.getElementById('labelToggle');
     if(adminLink) adminLink.style.display='none';
+    if(adminSug) adminSug.style.display='none';
     if(labelToggle) labelToggle.style.display='none';
     btn.classList.remove('user-name');
     btn.innerHTML='<i class="fa-solid fa-user"></i>';

--- a/src/js/components.jsx
+++ b/src/js/components.jsx
@@ -109,6 +109,7 @@ const Header = () => {
             </li>
             <li className="nav-item"><NavLink className="nav-link" to="/build" onClick={closeMenu} data-i18n="nav_build">Team builder</NavLink></li>
             <li className="nav-item" id="adminNav" style={{display:'none'}}><NavLink className="nav-link" to="/admin" onClick={closeMenu} data-i18n="nav_admin">Admin</NavLink></li>
+            <li className="nav-item" id="adminSuggestionsNav" style={{display:'none'}}><NavLink className="nav-link" to="/admin/suggestions" onClick={closeMenu} data-i18n="nav_admin_suggestions">Suggestions</NavLink></li>
           </ul>
           <div className="header-right">
             <div className="icon-bar header-actions">
@@ -157,7 +158,9 @@ const Header = () => {
 
 const Footer = () => (
   <footer className="text-center text-white py-3">
-    Copyright oPyRuSo 2025-{new Date().getFullYear()}
+    <NavLink className="footer-link" to="/suggest">
+      Copyright oPyRuSo 2025-{new Date().getFullYear()}
+    </NavLink>
   </footer>
 );
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -100,5 +100,16 @@
   "build_author_col": "Author",
   "build_updated_col": "Updated",
   "nav_inventories": "Inventories",
-  "my_account": "My Account"
+  "my_account": "My Account",
+  "footer_suggest": "Suggestion box",
+  "nav_admin_suggestions": "Suggestions",
+  "heading_suggestions_admin": "Suggestions",
+  "heading_suggest": "Submit a suggestion",
+  "suggestion_title": "Title",
+  "suggestion_description": "Description",
+  "suggestion_type": "Type",
+  "suggestion_send": "Send",
+  "suggestion_sent": "Suggestion sent",
+  "suggestion_failed": "Failed to send suggestion",
+  "delete_confirm": "Delete?"
 }

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -100,5 +100,16 @@
   "build_author_col": "Auteur",
   "build_updated_col": "Mise à jour",
   "nav_inventories": "Inventaires",
-  "my_account": "Mon compte"
+  "my_account": "Mon compte",
+  "footer_suggest": "Boite a idees",
+  "nav_admin_suggestions": "Suggestions",
+  "heading_suggestions_admin": "Suggestions",
+  "heading_suggest": "Envoyer une suggestion",
+  "suggestion_title": "Titre",
+  "suggestion_description": "Description",
+  "suggestion_type": "Type",
+  "suggestion_send": "Envoyer",
+  "suggestion_sent": "Suggestion envoyee",
+  "suggestion_failed": "Erreur lors de l'envoi",
+  "delete_confirm": "Supprimer?"
 }


### PR DESCRIPTION
## Summary
- link footer to new suggestion page
- enable admin suggestions nav visibility
- implement suggestion form and admin suggestion management pages
- hook up new routes in the React app
- style suggestion pages
- add translation keys

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b15383124832c802538c8c0d53038