### PR TITLE
Fix sub lumina modal highlight

### DIFF
--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -948,11 +948,10 @@ function BuildPage(){
   }
   function openSubsModal(idx){
     const locked = team[idx].mainPictos.filter(Boolean); // main pictos for this character
-    // highlight only pictos already selected on this character
-    const usedSet = new Set([...locked, ...team[idx].subPictos.filter(Boolean)]);
+    const subs = team[idx].subPictos.filter(Boolean);
     const opts = pictos
       .map(p => {
-        const used = usedSet.has(p.id);
+        const used = subs.includes(p.id); // highlight only currently selected subs
         return {
           value: p.id,
           label: p.name,
@@ -964,7 +963,7 @@ function BuildPage(){
       })
       .sort((a,b)=>a.label.localeCompare(b.label,currentLang,{sensitivity:'base'}));
     // pre-select current sub pictos and locked main pictos
-    const baseValues = [...usedSet];
+    const baseValues = [...locked, ...subs];
     if(editMode){
       setModal({
         options: opts,

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -948,12 +948,8 @@ function BuildPage(){
   }
   function openSubsModal(idx){
     const locked = team[idx].mainPictos.filter(Boolean); // main pictos for this character
-    // pictos used anywhere for highlighting
-    const usedSet = new Set();
-    team.forEach(c => {
-      c.mainPictos.forEach(p => p && usedSet.add(p));
-      c.subPictos.forEach(p => p && usedSet.add(p));
-    });
+    // highlight only pictos already selected on this character
+    const usedSet = new Set([...locked, ...team[idx].subPictos.filter(Boolean)]);
     const opts = pictos
       .map(p => {
         const used = usedSet.has(p.id);
@@ -967,8 +963,8 @@ function BuildPage(){
         };
       })
       .sort((a,b)=>a.label.localeCompare(b.label,currentLang,{sensitivity:'base'}));
-    // pre-select only the current sub pictos
-    const baseValues = [...team[idx].subPictos];
+    // pre-select current sub pictos and locked main pictos
+    const baseValues = [...usedSet];
     if(editMode){
       setModal({
         options: opts,


### PR DESCRIPTION
## Summary
- prevent highlighting lumina from other characters
- keep main pictos pre-selected and locked in the subs modal

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ba36a9540832cacc818872c25dbb6