### PR TITLE
Fix sub lumina deselection

### DIFF
--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -951,12 +951,10 @@ function BuildPage(){
     const subs = team[idx].subPictos.filter(Boolean);
     const opts = pictos
       .map(p => {
-        const used = subs.includes(p.id); // highlight only currently selected subs
         return {
           value: p.id,
           label: p.name,
           desc: p.bonus_lumina,
-          used,
           // only main pictos of this character are locked
           disabled: locked.includes(p.id)
         };


### PR DESCRIPTION
## Summary
- allow preselected secondary luminas to be deselected by removing the static `used` class

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688baa411c74832ca86ef0a91dd8d527