### PR TITLE
Enable tooltip on disabled lumina entries

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1193,7 +1193,9 @@ th, .info-icon, .char-select img, .picto-checkbox, input[type="checkbox"] {
 }
 .modal-option.disabled {
   opacity: 0.5;
-  pointer-events: none;
+  /* keep hover events so tooltips remain visible */
+  pointer-events: auto;
+  cursor: default;
 }
 .modal-options {
   display: flex;


### PR DESCRIPTION
## Summary
- keep hover events on disabled lumina options so that tooltips still appear

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688bac4701b8832c90c9b0b257b504d6