### PR TITLE
fix: send build metadata on share

### DIFF
--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -1011,7 +1011,14 @@ function BuildPage(){
     if(apiUrl){
       apiFetch(`${apiUrl}/public/builds`,{
         method:'POST',
-        body:{content:team,author:userId}
+        body:{
+          content:team,
+          author:userId,
+          id: buildMeta.id,
+          title: buildMeta.title,
+          description: buildMeta.description,
+          recommendedLevel: Number(buildMeta.level) || 0,
+        }
       })
         .then(r=>r.ok?r.json():Promise.reject())
         .then(({id})=>{


### PR DESCRIPTION
## Summary
- include build id, title, description and recommended level when sharing a build

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_688c121f0a48832cb4f159e4bce5fa77