### PR TITLE
Skip API call when sharing unchanged build

### DIFF
--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -1008,6 +1008,11 @@ function BuildPage(){
       .catch(()=>{});
 
     const userId=window.keycloak?.tokenParsed?.sub;
+    if(buildMeta.id){
+      const url=`${shareBase}/${encodeURIComponent(buildMeta.id)}`;
+      copyUrl(url);
+      return;
+    }
     if(apiUrl){
       apiFetch(`${apiUrl}/public/builds`,{
         method:'POST',


### PR DESCRIPTION
## Summary
- Avoid API request on Share when build `id` already present by copying link directly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c1792c5fc832c875e5b04e297e387